### PR TITLE
feat: Added Claim Stats EP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bagsfm/bags-sdk",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"description": "TypeScript SDK for Bags",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -1,5 +1,14 @@
 import { type Commitment, type Connection, PublicKey } from '@solana/web3.js';
-import type { BagsGetFeeShareWalletV2ApiResponse, BagsGetFeeShareWalletV2Response, BagsGetFeeShareWalletV2State, GetPoolConfigKeyByFeeClaimerVaultApiResponse, SupportedSocialProvider, TokenLaunchCreator } from '../types/api';
+import type {
+	BagsGetFeeShareWalletV2ApiResponse,
+	BagsGetFeeShareWalletV2Response,
+	BagsGetFeeShareWalletV2State,
+	GetPoolConfigKeyByFeeClaimerVaultApiResponse,
+	GetTokenClaimStatsV2Response,
+	SupportedSocialProvider,
+	TokenLaunchCreator,
+	TokenLaunchCreatorV3WithClaimStats,
+} from '../types/api';
 import type { Program } from '@coral-xyz/anchor';
 import type { DynamicBondingCurve as DynamicBondingCurveIDL } from '../idl/dynamic-bonding-curve/idl';
 import type { DammV2 as DammV2IDL } from '../idl/damm-v2/idl';
@@ -101,6 +110,26 @@ export class StateService {
 		});
 
 		return creators;
+	}
+
+	/**
+	 * Get token claim stats
+	 *
+	 * @param tokenMint The mint of the token to get the claim stats for
+	 * @returns The creators with claim stats
+	 */
+	async getTokenClaimStats(tokenMint: PublicKey): Promise<Array<TokenLaunchCreatorV3WithClaimStats>> {
+		const response = await this.bagsApiClient.get<GetTokenClaimStatsV2Response>('/token-launch/claim-stats', {
+			params: {
+				tokenMint: tokenMint.toBase58(),
+			},
+		});
+
+		if (!response.success) {
+			throw new Error('Failed to get token claim stats');
+		}
+
+		return response.response;
 	}
 
 	/**

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -70,3 +70,16 @@ export type TransactionTipConfig = {
 	tipWallet: PublicKey;
 	tipLamports: number;
 }
+
+export type TokenLaunchCreatorV3WithClaimStats = TokenLaunchCreator & {
+	totalClaimed: string;
+};
+export type GetTokenClaimStatsV2ErrorResponse = {
+	success: false;
+	response: string;
+};
+export type GetTokenClaimStatsV2SuccessResponse = {
+	success: true;
+	response: Array<TokenLaunchCreatorV3WithClaimStats>;
+};
+export type GetTokenClaimStatsV2Response = GetTokenClaimStatsV2SuccessResponse | GetTokenClaimStatsV2ErrorResponse;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds types and `StateService.getTokenClaimStats` to fetch token claim stats from `/token-launch/claim-stats`, and bumps package version.
> 
> - **SDK**:
>   - **StateService**: Add `getTokenClaimStats(tokenMint)` calling `/token-launch/claim-stats`, returning `Array<TokenLaunchCreatorV3WithClaimStats>`; throws on unsuccessful response.
> - **Types**:
>   - Add `TokenLaunchCreatorV3WithClaimStats` (extends `TokenLaunchCreator` with `totalClaimed`).
>   - Add `GetTokenClaimStatsV2Response` union with success/error variants.
> - **Release**:
>   - Bump `package.json` version to `1.0.9`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 388dd09374d214847b761c826b8343be8410ec45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->