### PR TITLE
feat: Added Top Tokens by Lifetime fees EP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bagsfm/bags-sdk",
-	"version": "1.0.8",
+	"version": "1.1.0",
 	"description": "TypeScript SDK for Bags",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -1,5 +1,5 @@
 import { type Commitment, type Connection, PublicKey } from '@solana/web3.js';
-import type { BagsGetFeeShareWalletV2ApiResponse, BagsGetFeeShareWalletV2Response, BagsGetFeeShareWalletV2State, GetPoolConfigKeyByFeeClaimerVaultApiResponse, SupportedSocialProvider, TokenLaunchCreator } from '../types/api';
+import type { BagsGetFeeShareWalletV2ApiResponse, BagsGetFeeShareWalletV2Response, BagsGetFeeShareWalletV2State, GetPoolConfigKeyByFeeClaimerVaultApiResponse, GetTopTokensByLifetimeFeesResponse, SupportedSocialProvider, TokenLaunchCreator, BagsTokenLeaderBoardItem } from '../types/api';
 import type { Program } from '@coral-xyz/anchor';
 import type { DynamicBondingCurve as DynamicBondingCurveIDL } from '../idl/dynamic-bonding-curve/idl';
 import type { DammV2 as DammV2IDL } from '../idl/damm-v2/idl';
@@ -101,6 +101,21 @@ export class StateService {
 		});
 
 		return creators;
+	}
+
+	/**
+	 * Get top tokens by lifetime fees
+	 *
+	 * @returns The leaderboard items
+	 */
+	async getTopTokensByLifetimeFees(): Promise<Array<BagsTokenLeaderBoardItem>> {
+		const response = await this.bagsApiClient.get<GetTopTokensByLifetimeFeesResponse>('/token-launch/top-tokens/lifetime-fees');
+
+		if (!response.success) {
+			throw new Error('Failed to get top tokens by lifetime fees');
+		}
+
+		return response.response;
 	}
 
 	/**

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -70,3 +70,119 @@ export type TransactionTipConfig = {
 	tipWallet: PublicKey;
 	tipLamports: number;
 }
+
+export interface JupiterTokenFirstPool {
+	id: string;
+	createdAt: string;
+}
+
+export interface JupiterTokenAudit {
+	topHoldersPercentage?: number;
+	highSingleOwnership?: boolean;
+	blockaidHoneypot?: boolean;
+	mintAuthorityDisabled?: boolean;
+	freezeAuthorityDisabled?: boolean;
+	devMigrations?: number;
+	blockaidRugpull?: boolean;
+	blockaidWashTrading?: boolean;
+	blockaidHiddenKeyHolder?: boolean;
+}
+
+export interface JupiterTokenStats {
+	priceChange?: number;
+	holderChange?: number;
+	liquidityChange?: number;
+	volumeChange?: number;
+	buyVolume?: number;
+	sellVolume?: number;
+	buyOrganicVolume?: number;
+	sellOrganicVolume?: number;
+	numBuys?: number;
+	numSells?: number;
+	numTraders?: number;
+	numOrganicBuyers?: number;
+	numNetBuyers?: number;
+}
+
+export interface JupiterToken {
+	id: string;
+	name: string;
+	symbol: string;
+	icon: string;
+	decimals: number;
+	twitter?: string;
+	website?: string;
+	telegram?: string;
+	dev: string;
+	circSupply: number;
+	totalSupply: number;
+	tokenProgram: string;
+	launchpad?: string;
+	metaLaunchpad?: string;
+	partnerConfig?: string;
+	mintAuthority?: string;
+	freezeAuthority?: string;
+	firstPool: JupiterTokenFirstPool;
+	graduatedPool?: string;
+	graduatedAt?: string;
+	holderCount: number;
+	audit: JupiterTokenAudit;
+	organicScore: number;
+	organicScoreLabel: string;
+	tags: string[];
+	fdv: number;
+	mcap: number;
+	usdPrice: number;
+	priceBlockId: number;
+	liquidity: number;
+	stats5m?: JupiterTokenStats;
+	stats1h?: JupiterTokenStats;
+	stats6h?: JupiterTokenStats;
+	stats24h?: JupiterTokenStats;
+	bondingCurve?: number;
+	ctLikes?: number;
+	smartCtLikes?: number;
+	updatedAt: string;
+}
+
+export type TokenAmount = {
+	/** Raw amount of tokens as string ignoring decimals */
+	amount: string;
+	/** Number of decimals configured for token's mint */
+	decimals: number;
+	/** Token amount as float, accounts for decimals */
+	uiAmount: number | null;
+	/** Token amount as string, accounts for decimals */
+	uiAmountString?: string;
+};
+
+export type TokenLatestPrice = {
+	price: number;
+	priceUSD: number;
+	priceSOL: number;
+	volumeUSD: number;
+	volumeSOL: number;
+	tokenAddress: string;
+	blockTime: string;
+};
+
+export type BagsTokenLeaderBoardItem = {
+	token: string,
+	lifetimeFees: string,
+	tokenInfo: JupiterToken | null,
+	creators: Array<TokenLaunchCreator> | null,
+	tokenSupply: TokenAmount | null,
+	tokenLatestPrice: TokenLatestPrice | null
+};
+
+export type GetTopTokensByLifetimeFeesSuccessResponse = {
+	success: true;
+	response: Array<BagsTokenLeaderBoardItem>;
+};
+
+export type GetTopTokensByLifetimeFeesErrorResponse = {
+	success: false;
+	response: string;
+};
+
+export type GetTopTokensByLifetimeFeesResponse = GetTopTokensByLifetimeFeesSuccessResponse | GetTopTokensByLifetimeFeesErrorResponse;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Top Tokens by Lifetime Fees endpoint support with new types and StateService method; bump version to 1.1.0.
> 
> - **SDK Service (`src/services/state.ts`)**:
>   - Add `getTopTokensByLifetimeFees()` calling `/token-launch/top-tokens/lifetime-fees`, returning `Array<BagsTokenLeaderBoardItem>` and throwing on failure.
> - **Types (`src/types/api.ts`)**:
>   - Introduce leaderboard and token metadata models: `BagsTokenLeaderBoardItem`, `GetTopTokensByLifetimeFeesResponse` (+ success/error variants), `JupiterToken` (+ `FirstPool`, `Audit`, `Stats`), `TokenAmount`, `TokenLatestPrice`.
> - **Version**:
>   - Bump `package.json` to `1.1.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bce227ade01bb495adcd2744ab104f5d875c27cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->