### PR TITLE
feat: Fee Share Wallet Bulk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bagsfm/bags-sdk",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "TypeScript SDK for Bags",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -1,7 +1,10 @@
 import { type Commitment, type Connection, PublicKey } from '@solana/web3.js';
 import type {
+	BagsGetFeeShareWalletV2BulkResponseItem,
+	BagsGetFeeShareWalletV2BulkStateItem,
 	BagsGetFeeShareWalletV2Response,
 	BagsGetFeeShareWalletV2State,
+	GetLaunchWalletV2BulkRequestItem,
 	GetPoolConfigKeyByFeeClaimerVaultApiResponse,
 	GetTokenClaimStatsV2Response,
 	SupportedSocialProvider,
@@ -213,6 +216,30 @@ export class StateService {
 			};
 		} catch (error: unknown) {
 			throw new Error(`Failed to get launch wallet for ${provider} user ${username}: ${(error as Error)?.message}`);
+		}
+	}
+
+	/**
+	 * Get launch wallets for multiple social usernames
+	 *
+	 * @param items The usernames and providers to fetch launch wallets for
+	 * @returns The launch wallets state for each requested user
+	 * @throws Error if the request fails or the response indicates failure
+	 */
+	async getLaunchWalletV2Bulk(items: Array<GetLaunchWalletV2BulkRequestItem>): Promise<Array<BagsGetFeeShareWalletV2BulkStateItem>> {
+		try {
+			const response = await this.bagsApiClient.post<Array<BagsGetFeeShareWalletV2BulkResponseItem>>('/token-launch/fee-share/wallet/v2/bulk', {
+				items,
+			});
+
+			return response.map((item) => ({
+				username: item.username,
+				provider: item.provider,
+				platformData: item.platformData,
+				wallet: item.wallet ? new PublicKey(item.wallet) : null,
+			}));
+		} catch (error: unknown) {
+			throw new Error(`Failed to get launch wallets in bulk: ${(error as Error)?.message}`);
 		}
 	}
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -101,3 +101,22 @@ export type GetTokenClaimStatsV2Response = {
 	success: true;
 	response: Array<TokenLaunchCreatorV3WithClaimStats>;
 };
+
+export type GetLaunchWalletV2BulkRequestItem = {
+	username: string;
+	provider: SupportedSocialProvider;
+};
+
+export type BagsGetFeeShareWalletV2BulkResponseItem = {
+	username: string;
+	provider: BagsGetFeeShareWalletV2Response['provider'];
+	platformData: BagsGetFeeShareWalletV2Response['platformData'] | null;
+	wallet: string | null;
+};
+
+export type BagsGetFeeShareWalletV2BulkStateItem = {
+	username: string;
+	provider: BagsGetFeeShareWalletV2State['provider'];
+	platformData: BagsGetFeeShareWalletV2State['platformData'] | null;
+	wallet: BagsGetFeeShareWalletV2State['wallet'] | null;
+};

--- a/tests/services/state.test.ts
+++ b/tests/services/state.test.ts
@@ -37,6 +37,20 @@ describe('StateService integration', () => {
 		expect(v2Result.wallet.equals(legacyWallet)).toBe(true);
 	});
 
+	test('getLaunchWalletV2Bulk returns consistent results with the single fetch', async () => {
+		const { state } = getTestSdk();
+		const legacyWallet = await state.getLaunchWalletForTwitterUsername(testEnv.socialUsername);
+		const [bulkResult] = await state.getLaunchWalletV2Bulk([{ username: testEnv.socialUsername, provider: 'twitter' }]);
+		const singleResult = await state.getLaunchWalletV2(testEnv.socialUsername, 'twitter');
+
+		expect(bulkResult).toBeDefined();
+		expect(bulkResult.provider).toBe('twitter');
+		expect(bulkResult.wallet).not.toBeNull();
+		expect(bulkResult.wallet).toBeInstanceOf(PublicKey);
+		expect(bulkResult.wallet?.equals(singleResult.wallet)).toBe(true);
+		expect(bulkResult.wallet?.equals(legacyWallet)).toBe(true);
+	});
+
 	test('program getters expose expected program ids', () => {
 		const { state } = getTestSdk();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `getLaunchWalletV2Bulk` with supporting types and tests to fetch multiple fee-share launch wallets at once, and bumps version to 1.2.2.
> 
> - **SDK State Service**:
>   - Add `getLaunchWalletV2Bulk` to fetch multiple launch wallets via `/token-launch/fee-share/wallet/v2/bulk`, mapping responses to state items and handling null wallets.
> - **Types**:
>   - Introduce `GetLaunchWalletV2BulkRequestItem`, `BagsGetFeeShareWalletV2BulkResponseItem`, and `BagsGetFeeShareWalletV2BulkStateItem` in `src/types/api.ts`.
> - **Tests**:
>   - Add integration test ensuring bulk results match single `getLaunchWalletV2` and legacy method.
> - **Version**:
>   - Bump `package.json` version to `1.2.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff168858bf0ea41772f2a49ac83d4f67eaa63d59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->