### PR TITLE
refactor: legacy to versioned tx

### DIFF
--- a/src/services/fees.ts
+++ b/src/services/fees.ts
@@ -1,4 +1,4 @@
-import { Commitment, Connection, PublicKey, Transaction } from '@solana/web3.js';
+import { Commitment, Connection, PublicKey, VersionedTransaction } from '@solana/web3.js';
 import { BaseService } from './base';
 import { BagsClaimablePosition } from '../types/meteora';
 import { ClaimTransactionApiResponse } from '../types';
@@ -30,9 +30,9 @@ export class FeesService extends BaseService {
 	 *
 	 * @param wallet The public key of the wallet claiming fees
 	 * @param tokenMint The mint address of the token to claim fees for
-	 * @returns Array of transactions to claim fees
+	 * @returns Array of versioned transactions to claim fees
 	 */
-	async getClaimTransactions(wallet: PublicKey, tokenMint: PublicKey): Promise<Array<Transaction>> {
+	async getClaimTransactions(wallet: PublicKey, tokenMint: PublicKey): Promise<Array<VersionedTransaction>> {
 		const response = await this.bagsApiClient.post<ClaimTransactionApiResponse>('/token-launch/claim-txs/v3', {
 			feeClaimer: wallet.toBase58(),
 			tokenMint: tokenMint.toBase58(),
@@ -40,7 +40,7 @@ export class FeesService extends BaseService {
 
 		const deserializedTransactions = response.map((tx) => {
 			const decodedTransaction = bs58.decode(tx.tx);
-			return Transaction.from(decodedTransaction);
+			return VersionedTransaction.deserialize(decodedTransaction);
 		});
 
 		return deserializedTransactions;

--- a/tests/services/fees.test.ts
+++ b/tests/services/fees.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, test } from 'vitest';
-import { LAMPORTS_PER_SOL, PublicKey, Transaction } from '@solana/web3.js';
+import { LAMPORTS_PER_SOL, PublicKey, VersionedTransaction } from '@solana/web3.js';
 import { getTestSdk } from '../helpers/sdk';
 import type { BagsClaimablePosition } from '../../src/types/meteora';
 import { testEnv } from '../helpers/env';
@@ -36,7 +36,7 @@ describe('FeesService integration', () => {
 		expect(transactions.length).toBeGreaterThan(0);
 
 		transactions.forEach((tx) => {
-			expect(tx).toBeInstanceOf(Transaction);
+			expect(tx).toBeInstanceOf(VersionedTransaction);
 		});
 	});
 });

--- a/tests/services/fees.test.ts
+++ b/tests/services/fees.test.ts
@@ -23,7 +23,10 @@ describe('FeesService integration', () => {
 			throw new Error('No claimable positions found');
 		}
 
-		const maxClaimablePosition = claimablePositions.reduce((max, current) => current.totalClaimableLamportsUserShare > max.totalClaimableLamportsUserShare ? current : max, claimablePositions[0]);
+		const maxClaimablePosition = claimablePositions.reduce(
+			(max, current) => (current.totalClaimableLamportsUserShare > max.totalClaimableLamportsUserShare ? current : max),
+			claimablePositions[0]
+		);
 
 		// if max claimable position is less than 0.0001 SOL, throw an error
 		if (maxClaimablePosition.totalClaimableLamportsUserShare < 0.0001 * LAMPORTS_PER_SOL) {
@@ -40,4 +43,3 @@ describe('FeesService integration', () => {
 		});
 	});
 });
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `FeesService.getClaimTransactions` public API from legacy `Transaction` to `VersionedTransaction`, which may break downstream consumers and affects how claim TXs are signed/sent.
> 
> **Overview**
> Updates fee-claim transaction handling to use Solana `VersionedTransaction` instead of legacy `Transaction`.
> 
> `FeesService.getClaimTransactions` now returns deserialized versioned transactions via `VersionedTransaction.deserialize`, and the integration test is updated to assert the new transaction type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baa856c6f72c7b5784bb54c592036a4ed3c91a3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->