### PR TITLE
feat: Auth Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ new BagsSDK(apiKey: string, connection: Connection, commitment?: Commitment)
 | **Fee Share Admin** | `sdk.feeShareAdmin` | Transfer admin roles, list admin mints, and update fee-share configs |
 | **Dexscreener** | `sdk.dexscreener` | Check order availability, create orders, and submit payments for Dexscreener listings |
 | **Incorporation** | `sdk.incorporation` | Start payments, register incorporation details, and manage incorporation projects |
+| **Auth** | `sdk.auth` | Fetch the API key owner's user profile |
 
 ### Exported Utilities
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bagsfm/bags-sdk",
-	"version": "1.3.6",
+	"version": "1.3.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bagsfm/bags-sdk",
-	"version": "1.3.6",
+	"version": "1.3.7",
 	"description": "TypeScript SDK for Bags",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,6 +10,7 @@ import { SolanaService } from './services/solana';
 import { FeeShareAdminService } from './services/fee-share-admin';
 import { DexscreenerService } from './services/dexscreener';
 import { IncorporationService } from './services/incorporation';
+import { AuthService } from './services/auth';
 
 export class BagsSDK {
 	public bagsApiClient: BagsApiClient;
@@ -23,6 +24,7 @@ export class BagsSDK {
 	public feeShareAdmin: FeeShareAdminService;
 	public dexscreener: DexscreenerService;
 	public incorporation: IncorporationService;
+	public auth: AuthService;
 
 	constructor(apiKey: string, connection: Connection, commitment: Commitment = 'processed') {
 		this.bagsApiClient = new BagsApiClient(apiKey);
@@ -36,5 +38,6 @@ export class BagsSDK {
 		this.feeShareAdmin = new FeeShareAdminService(apiKey, connection, commitment);
 		this.dexscreener = new DexscreenerService(apiKey, connection, commitment);
 		this.incorporation = new IncorporationService(apiKey, connection, commitment);
+		this.auth = new AuthService(apiKey, connection, commitment);
 	}
 }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,18 @@
+import { Commitment, Connection } from '@solana/web3.js';
+import { BaseService } from './base';
+import type { AuthMeResponse } from '../types';
+
+export class AuthService extends BaseService {
+	constructor(apiKey: string, connection: Connection, commitment: Commitment = 'processed') {
+		super(apiKey, connection, commitment);
+	}
+
+	/**
+	 * Get information about the user that owns the current API key.
+	 *
+	 * @returns The authenticated Bags user profile.
+	 */
+	async me(): Promise<AuthMeResponse> {
+		return this.bagsApiClient.get<AuthMeResponse>('/auth/me');
+	}
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,31 @@
+export interface AuthMeTwitterData {
+	verified: boolean;
+	followers_count: number;
+	following_count: number;
+	created_at: string;
+	url: string;
+}
+
+export interface AuthMeUser {
+	uuid: string;
+	type: string;
+	membership: Record<string, unknown>;
+	ticker: string;
+	username: string;
+	status: string;
+	pref_name: string;
+	picture: string;
+	twitter_userID: string;
+	registered_at: string;
+	profile_views: number;
+	invites: number;
+	invited_by: string;
+	twitter_data: AuthMeTwitterData;
+	points: number;
+	rank: number;
+	referral_count: number;
+}
+
+export interface AuthMeResponse {
+	user: AuthMeUser;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './api';
+export * from './auth';
 export * from './token-launch';
 export * from './trade';
 export * from './solana';

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -12,6 +12,7 @@ describe('BagsSDK', () => {
 		expect(sdk.fee).toBeDefined();
 		expect(sdk.partner).toBeDefined();
 		expect(sdk.feeShareAdmin).toBeDefined();
+		expect(sdk.auth).toBeDefined();
 	});
 
 	test('state service shares connection and commitment', () => {

--- a/tests/services/auth.test.ts
+++ b/tests/services/auth.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'vitest';
+import { getTestSdk } from '../helpers/sdk';
+
+describe('AuthService integration', () => {
+	test('me returns user data for the API key owner', async () => {
+		const { auth } = getTestSdk();
+		const response = await auth.me();
+
+		expect(response.user).toBeDefined();
+		expect(typeof response.user.uuid).toBe('string');
+		expect(response.user.uuid.length).toBeGreaterThan(0);
+		expect(typeof response.user.username).toBe('string');
+		expect(response.user.username.length).toBeGreaterThan(0);
+		expect(typeof response.user.twitter_data.verified).toBe('boolean');
+		expect(typeof response.user.twitter_data.followers_count).toBe('number');
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk additive change: introduces a new `sdk.auth.me()` wrapper around a single `/auth/me` API call plus types/tests, with no changes to existing service behavior.
> 
> **Overview**
> Adds a new **Auth** surface to the SDK (`sdk.auth`) that can fetch the current API key owner’s user profile via `GET /auth/me`.
> 
> Introduces `AuthService`, exports new `AuthMe*` response types, updates docs/tests to cover the new service, and bumps the package version to `1.3.7`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8b6b4e18b7caeccfb51ea526533353da5f9d910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->