### PR TITLE
fix: getTokenClaimStats always threw on success Closes #27

### DIFF
--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -8,7 +8,6 @@ import type {
 	GetLaunchWalletV2BulkRequestItem,
 	GetPoolConfigKeyByFeeClaimerVaultApiResponse,
 	GetTokenClaimEventsSuccessResponse,
-	GetTokenClaimStatsV2Response,
 	SupportedSocialProvider,
 	TokenClaimEvent,
 	TokenLaunchCreator,
@@ -193,17 +192,14 @@ export class StateService {
 	 * @returns The creators with claim stats
 	 */
 	async getTokenClaimStats(tokenMint: PublicKey): Promise<Array<TokenLaunchCreatorV3WithClaimStats>> {
-		const response = await this.bagsApiClient.get<GetTokenClaimStatsV2Response>('/token-launch/claim-stats', {
+		// get() already unwraps the { success, response } envelope, so the generic is the inner payload.
+		const response = await this.bagsApiClient.get<Array<TokenLaunchCreatorV3WithClaimStats>>('/token-launch/claim-stats', {
 			params: {
 				tokenMint: tokenMint.toBase58(),
 			},
 		});
 
-		if (!response.success) {
-			throw new Error('Failed to get token claim stats');
-		}
-
-		return response.response;
+		return response;
 	}
 
 	/**

--- a/tests/services/state.test.ts
+++ b/tests/services/state.test.ts
@@ -76,5 +76,16 @@ describe('StateService integration', () => {
 		expect(typeof first.token).toBe('string');
 		expect(() => new PublicKey(first.token)).not.toThrow();
 	});
-});
 
+	test('getTokenClaimStats resolves creator claim stats without throwing', async () => {
+		const { state } = getTestSdk();
+		const stats = await state.getTokenClaimStats(testEnv.tokenMint);
+
+		expect(Array.isArray(stats)).toBe(true);
+
+		for (const item of stats) {
+			expect(typeof item.wallet).toBe('string');
+			expect(typeof item.totalClaimed).toBe('string');
+		}
+	});
+});


### PR DESCRIPTION

Closes #27.

`get()` already unwraps the `{ success, response }` envelope, but `getTokenClaimStats` typed the generic as the envelope and re-checked `.success` on the returned array — so it threw on every successful call.

Fixed by typing the generic as `Array<TokenLaunchCreatorV3WithClaimStats>` and returning it directly, like `getTokenClaimEvents`. Added a regression test, and left the exported `GetTokenClaimStatsV2Response` type in place so nothing breaks for consumers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bugfix in one state service method plus a test; no auth, security, or breaking API surface changes beyond restoring intended behavior.
> 
> **Overview**
> **Fixes a bug where `getTokenClaimStats` failed on every successful API call** (closes #27).
> 
> `BagsApiClient.get()` already returns the inner payload from the `{ success, response }` envelope. The method had typed `get` as `GetTokenClaimStatsV2Response` and then checked `.success` on the value—which was actually the stats array—so it always threw. It now types the call as `Array<TokenLaunchCreatorV3WithClaimStats>` and returns that directly, consistent with methods like `getTokenCreators`. The unused `GetTokenClaimStatsV2Response` import was removed from `state.ts`; the exported type remains for consumers.
> 
> An integration test asserts `getTokenClaimStats` returns an array of items with `wallet` and `totalClaimed` strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 839ee48362e7f7216c4c04b440f5ddbbd3a14fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->