### PR TITLE
feat: rh top volume method

### DIFF
--- a/src/services/robinhood.ts
+++ b/src/services/robinhood.ts
@@ -1,6 +1,11 @@
 import { Commitment, Connection } from '@solana/web3.js';
 import { BaseService } from './base';
-import { CreateRobinhoodClaimTransactionsParams, RobinhoodClaimablePositions, RobinhoodClaimTransactions } from '../types/robinhood';
+import {
+	CreateRobinhoodClaimTransactionsParams,
+	RobinhoodClaimablePositions,
+	RobinhoodClaimTransactions,
+	RobinhoodTopVolumeResponse,
+} from '../types/robinhood';
 
 export class RobinhoodService extends BaseService {
 	constructor(apiKey: string, connection: Connection, commitment: Commitment = 'processed') {
@@ -16,6 +21,15 @@ export class RobinhoodService extends BaseService {
 		return this.bagsApiClient.get<RobinhoodClaimablePositions>('/evm/rh/claimable-positions', {
 			params: { owner },
 		});
+	}
+
+	/**
+	 * Get the top 100 Robinhood Chain tokens by lifetime volume.
+	 *
+	 * @returns Tokens ranked by inferred lifetime ETH volume, highest first
+	 */
+	async getTopVolume(): Promise<RobinhoodTopVolumeResponse> {
+		return this.bagsApiClient.get<RobinhoodTopVolumeResponse>('/evm/rh/top-volume');
 	}
 
 	/**

--- a/src/types/robinhood.ts
+++ b/src/types/robinhood.ts
@@ -26,6 +26,16 @@ export interface RobinhoodToken {
 	version?: RobinhoodProtocolVersion;
 }
 
+export interface RobinhoodTopVolumeItem extends RobinhoodToken {
+	priceEthPerToken: string | null;
+	bondingProgressPct: number;
+	volumeEthWei: string;
+}
+
+export interface RobinhoodTopVolumeResponse {
+	items: Array<RobinhoodTopVolumeItem>;
+}
+
 export interface RobinhoodClaimablePosition {
 	token: RobinhoodToken;
 	feeShare: string;

--- a/tests/services/robinhood.test.ts
+++ b/tests/services/robinhood.test.ts
@@ -1,7 +1,36 @@
 import { beforeAll, describe, expect, test } from 'vitest';
 import { getTestSdk } from '../helpers/sdk';
 import { testEnv } from '../helpers/env';
-import type { RobinhoodClaimablePositions } from '../../src/types';
+import type { RobinhoodClaimablePositions, RobinhoodTopVolumeResponse } from '../../src/types';
+
+describe('RobinhoodService getTopVolume', () => {
+	let topVolume: RobinhoodTopVolumeResponse;
+
+	beforeAll(async () => {
+		topVolume = await getTestSdk().robinhood.getTopVolume();
+	});
+
+	test('returns tokens ranked by lifetime volume', () => {
+		expect(Array.isArray(topVolume.items)).toBe(true);
+		expect(topVolume.items.length).toBeLessThanOrEqual(100);
+
+		const item = topVolume.items[0];
+
+		if (!item) {
+			return;
+		}
+
+		expect(typeof item.address).toBe('string');
+		expect(typeof item.volumeEthWei).toBe('string');
+		expect(typeof item.bondingProgressPct).toBe('number');
+	});
+
+	test('items are sorted by volumeEthWei descending', () => {
+		for (let i = 1; i < topVolume.items.length; i++) {
+			expect(BigInt(topVolume.items[i - 1].volumeEthWei) >= BigInt(topVolume.items[i].volumeEthWei)).toBe(true);
+		}
+	});
+});
 
 describe.skipIf(!testEnv.robinhoodOwner)('RobinhoodService integration', () => {
 	let claimablePositions: RobinhoodClaimablePositions;


### PR DESCRIPTION
## Summary
- Wraps the new public endpoint `GET /evm/rh/top-volume` (backend PR bagsfm/bags.backend#1170) which returns the top 100 Robinhood Chain tokens by lifetime volume.
- Adds `RobinhoodTopVolumeItem` (extends `RobinhoodToken` with `priceEthPerToken`, `bondingProgressPct`, `volumeEthWei`) and `RobinhoodTopVolumeResponse` to `src/types/robinhood.ts`.
- Adds `RobinhoodService.getTopVolume()` in `src/services/robinhood.ts`, mirroring the existing `getClaimablePositions` method.
- Adds a test in `tests/services/robinhood.test.ts` that only requires `BAGS_API_KEY` (no `robinhoodOwner` needed, unlike the existing claim-flow tests).

## Test plan
- [x] `npm run build` passes.
- Note: this package is published manually via `npm publish` — a maintainer needs to release after merging before the corresponding `bags-cli` PR can depend on it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LMgZpbs2FwxUWf54a8wacv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only API wrapper and types with no auth, claims, or transaction changes.
> 
> **Overview**
> Exposes **`RobinhoodService.getTopVolume()`**, a read-only client for `GET /evm/rh/top-volume` that returns up to the top 100 Robinhood Chain tokens by lifetime ETH volume (highest first).
> 
> Adds **`RobinhoodTopVolumeItem`** and **`RobinhoodTopVolumeResponse`** so each row includes token metadata plus `priceEthPerToken`, `bondingProgressPct`, and `volumeEthWei`. Integration tests call the live API with only `BAGS_API_KEY` and assert shape, cap at 100 items, and descending `volumeEthWei` order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91e95c4dc25a5e3049494bbe8bfbb727191641ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->