### PR TITLE
feat: add token claim stats v4 method

### DIFF
--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -13,8 +13,11 @@ import type {
 	GetPoolConfigKeyByFeeClaimerVaultApiResponse,
 	GetTokenClaimEventsSuccessResponse,
 	GetTokenClaimStatsV2Response,
+	GetTokenClaimStatsV4Options,
+	GetTokenClaimStatsV4Response,
 	SupportedSocialProvider,
 	TokenClaimEvent,
+	TokenClaimStatsV4,
 	TokenLaunchCreator,
 	TokenLaunchCreatorV3WithClaimStats,
 } from '../types/api';
@@ -225,6 +228,37 @@ export class StateService {
 		});
 
 		console.log(response);
+		return response;
+	}
+
+	/**
+	 * Get token claim stats v4
+	 *
+	 * Reports claim totals per wallet broken down by the mint each amount was claimed in,
+	 * with a read-time USD conversion. Covers claims denominated in a pool's quote mint,
+	 * which `getTokenClaimStats` folds into a single SOL total and cannot represent.
+	 *
+	 * @param options Either the token mint to aggregate claims for, or the wallet to aggregate across all tokens it claimed on, plus optional forced-claim and user-enrichment flags
+	 * @returns The per-mint claim totals, sorted by total USD value descending
+	 */
+	async getTokenClaimStatsV4(options: GetTokenClaimStatsV4Options): Promise<Array<TokenClaimStatsV4>> {
+		const { tokenMint, wallet, includeForceClaim, includeUser } = options;
+
+		if ((tokenMint && wallet) || (!tokenMint && !wallet)) {
+			throw new Error('Either tokenMint or wallet must be provided, but not both');
+		}
+
+		const params: Record<string, string> = {};
+
+		if (tokenMint) params.tokenMint = tokenMint.toBase58();
+		if (wallet) params.wallet = wallet.toBase58();
+		if (includeForceClaim !== undefined) params.includeForceClaim = String(includeForceClaim);
+		if (includeUser !== undefined) params.includeUser = String(includeUser);
+
+		const response = await this.bagsApiClient.get<GetTokenClaimStatsV4Response>('/token-launch/claim-stats/v4', {
+			params,
+		});
+
 		return response;
 	}
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -147,6 +147,30 @@ export type TokenLaunchCreatorV3WithClaimStats = {
 
 export type GetTokenClaimStatsV2Response = Array<TokenLaunchCreatorV3WithClaimStats>;
 
+export type TokenClaimAmount = {
+	mint: string;
+	decimals: number;
+	amount: string;
+	amountUsd: number | null;
+};
+
+export type TokenClaimStatsV4 = {
+	wallet: string;
+	tokenMint: string;
+	claims: Array<TokenClaimAmount>;
+	totalClaimedUsd: number | null;
+	user?: Omit<TokenLaunchCreator, 'royaltyBps' | 'isCreator'>;
+};
+
+export type GetTokenClaimStatsV4Response = Array<TokenClaimStatsV4>;
+
+export type GetTokenClaimStatsV4Options = {
+	tokenMint?: PublicKey;
+	wallet?: PublicKey;
+	includeForceClaim?: boolean;
+	includeUser?: boolean;
+};
+
 export type GetLaunchWalletV2BulkRequestItem = {
 	username: string;
 	provider: SupportedSocialProvider;

--- a/tests/services/state.test.ts
+++ b/tests/services/state.test.ts
@@ -98,5 +98,51 @@ describe('StateService integration', () => {
 			expect(Number(entry.totalClaimed)).toBeGreaterThanOrEqual(0);
 		}
 	});
+
+	test('getTokenClaimStatsV4 returns per-mint claim amounts for the requested token mint', async () => {
+		const { state } = getTestSdk();
+		const stats = await state.getTokenClaimStatsV4({ tokenMint: testEnv.tokenMint });
+
+		expect(Array.isArray(stats)).toBe(true);
+		expect(stats.length).toBeGreaterThan(0);
+
+		const expectedMint = testEnv.tokenMint.toBase58();
+
+		for (const entry of stats) {
+			expect(typeof entry.wallet).toBe('string');
+			expect(() => new PublicKey(entry.wallet)).not.toThrow();
+
+			expect(entry.tokenMint).toBe(expectedMint);
+
+			expect(Array.isArray(entry.claims)).toBe(true);
+			expect(entry.claims.length).toBeGreaterThan(0);
+
+			for (const claim of entry.claims) {
+				expect(() => new PublicKey(claim.mint)).not.toThrow();
+
+				expect(typeof claim.decimals).toBe('number');
+				expect(Number.isInteger(claim.decimals)).toBe(true);
+
+				expect(typeof claim.amount).toBe('string');
+				expect(Number(claim.amount)).toBeGreaterThan(0);
+
+				if (claim.amountUsd !== null) {
+					expect(typeof claim.amountUsd).toBe('number');
+					expect(claim.amountUsd).toBeGreaterThanOrEqual(0);
+				}
+			}
+
+			if (entry.totalClaimedUsd !== null) {
+				expect(typeof entry.totalClaimedUsd).toBe('number');
+			}
+		}
+	});
+
+	test('getTokenClaimStatsV4 rejects queries that are not exactly one of tokenMint or wallet', async () => {
+		const { state } = getTestSdk();
+
+		await expect(state.getTokenClaimStatsV4({})).rejects.toThrow();
+		await expect(state.getTokenClaimStatsV4({ tokenMint: testEnv.tokenMint, wallet: testEnv.tokenMint })).rejects.toThrow();
+	});
 });
 


### PR DESCRIPTION
Wraps the new `GET /token-launch/claim-stats/v4` public API endpoint.

Changes:
- `src/types/api.ts` — adds `TokenClaimAmount`, `TokenClaimStatsV4`, `GetTokenClaimStatsV4Response`, and `GetTokenClaimStatsV4Options`. The `user` field reuses the existing `TokenLaunchCreator` type via `Omit<TokenLaunchCreator, 'royaltyBps' | 'isCreator'>`, matching what the backend actually returns.
- `src/services/state.ts` — adds `StateService.getTokenClaimStatsV4`.
- `tests/services/state.test.ts` — adds coverage for the token-mint query and for the argument validation.

The method takes an options object rather than a positional mint, because the endpoint accepts either `tokenMint` or `wallet` and requires exactly one of them. That constraint is enforced client-side so callers get a clear error instead of a 400. Raw amounts stay as strings to preserve u64 precision, consistent with `getTokenClaimStats`.

This is additive — `getTokenClaimStats` is untouched and still points at the unversioned path backed by v3.

`npm run build` passes. The new tests follow the existing integration-test pattern in this file and need live credentials (`BAGS_API_KEY` and the `BAGS_TEST_*` vars) to run, which weren't available here, so they have not been executed against the live API yet.

Release note: the SDK is published manually with `npm publish`, so a maintainer needs to cut a release after this merges before consumers can use the new method.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4BMRfQYAoBZQCVWvGK56T)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK wrapper around a new read-only endpoint; existing claim-stats APIs are untouched. No auth, writes, or data-handling changes.
> 
> **Overview**
> Adds `StateService.getTokenClaimStatsV4`, wrapping `GET /token-launch/claim-stats/v4`. Unlike `getTokenClaimStats`, it reports claim totals **per wallet broken down by claimed mint**, with optional USD conversion, instead of folding everything into a single SOL total.
> 
> Callers pass either `tokenMint` or `wallet` (exactly one), plus optional `includeForceClaim` and `includeUser`. The client rejects invalid combinations before hitting the API. Existing `getTokenClaimStats` is unchanged.
> 
> New types (`TokenClaimAmount`, `TokenClaimStatsV4`, options/response) live in `api.ts`. Integration tests cover the mint query and argument validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88780ae6d7cc870a17be7fe07256d661f039b830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->