### PR TITLE
feat: add global claim feed v2 method

### DIFF
--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -11,6 +11,8 @@ import type {
 	FeeShareWalletChain,
 	GetLaunchWalletV2BulkRequestItem,
 	GetPoolConfigKeyByFeeClaimerVaultApiResponse,
+	GetGlobalClaimFeedV2Options,
+	GetGlobalClaimFeedV2Response,
 	GetTokenClaimEventsSuccessResponse,
 	GetTokenClaimStatsV2Response,
 	SupportedSocialProvider,
@@ -225,6 +227,41 @@ export class StateService {
 		});
 
 		console.log(response);
+		return response;
+	}
+
+	/**
+	 * Get the global claim feed v2
+	 *
+	 * Returns fee-claim events across all tokens, newest first. Each event carries the mint
+	 * the amount was claimed in, that mint's decimals, and a read-time USD value, so claims
+	 * denominated in a pool's quote mint rather than SOL are represented correctly.
+	 *
+	 * Page backwards by passing the last event's `timestamp` as `before`. Forced claims are
+	 * excluded from this feed.
+	 *
+	 * @param options Optional pagination, amount bounds, and first-claim filtering
+	 * @returns The claim events and whether older events remain
+	 */
+	async getGlobalClaimFeedV2(options: GetGlobalClaimFeedV2Options = {}): Promise<GetGlobalClaimFeedV2Response> {
+		const { limit, before, minAmount, maxAmount, onlyFirstClaims } = options;
+
+		if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 100)) {
+			throw new Error('limit must be an integer between 1 and 100');
+		}
+
+		const params: Record<string, string | number> = {};
+
+		if (limit !== undefined) params.limit = limit;
+		if (before !== undefined) params.before = before;
+		if (minAmount !== undefined) params.minAmount = minAmount;
+		if (maxAmount !== undefined) params.maxAmount = maxAmount;
+		if (onlyFirstClaims !== undefined) params.onlyFirstClaims = String(onlyFirstClaims);
+
+		const response = await this.bagsApiClient.get<GetGlobalClaimFeedV2Response>('/feed/global-claim/v2', {
+			params,
+		});
+
 		return response;
 	}
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -191,6 +191,39 @@ export type GetTokenClaimEventsSuccessResponse = {
 	events: Array<TokenClaimEvent>;
 };
 
+export type ForceClaimType = 'Unknown' | 'Admin' | 'Manager';
+
+export type GlobalClaimEventV2 = {
+	tokenMint: string;
+	user: TokenLaunchCreator | null;
+	wallet: string;
+	isCreator: boolean;
+	amount: string;
+	mint: string;
+	decimals: number;
+	amountUsd: number | null;
+	signature: string;
+	timestamp: number;
+	isFirstClaim: boolean;
+	preMigrationPool: string | null;
+	postMigrationPool: string | null;
+	isForceClaim: boolean;
+	forceClaimType: ForceClaimType | null;
+};
+
+export type GetGlobalClaimFeedV2Response = {
+	events: Array<GlobalClaimEventV2>;
+	hasMore: boolean;
+};
+
+export type GetGlobalClaimFeedV2Options = {
+	limit?: number;
+	before?: number;
+	minAmount?: number;
+	maxAmount?: number;
+	onlyFirstClaims?: boolean;
+};
+
 export interface JupiterTokenFirstPool {
 	id: string;
 	createdAt: string;

--- a/tests/services/state.test.ts
+++ b/tests/services/state.test.ts
@@ -98,5 +98,58 @@ describe('StateService integration', () => {
 			expect(Number(entry.totalClaimed)).toBeGreaterThanOrEqual(0);
 		}
 	});
+
+	test('getGlobalClaimFeedV2 returns claim events newest first with per-mint denomination', async () => {
+		const { state } = getTestSdk();
+		const feed = await state.getGlobalClaimFeedV2({ limit: 10 });
+
+		expect(Array.isArray(feed.events)).toBe(true);
+		expect(typeof feed.hasMore).toBe('boolean');
+		expect(feed.events.length).toBeGreaterThan(0);
+		expect(feed.events.length).toBeLessThanOrEqual(10);
+
+		for (const event of feed.events) {
+			expect(() => new PublicKey(event.tokenMint)).not.toThrow();
+			expect(() => new PublicKey(event.wallet)).not.toThrow();
+			expect(() => new PublicKey(event.mint)).not.toThrow();
+
+			expect(typeof event.amount).toBe('string');
+			expect(Number(event.amount)).toBeGreaterThan(0);
+
+			expect(Number.isInteger(event.decimals)).toBe(true);
+			expect(typeof event.signature).toBe('string');
+			expect(Number.isInteger(event.timestamp)).toBe(true);
+			expect(typeof event.isFirstClaim).toBe('boolean');
+
+			if (event.amountUsd !== null) {
+				expect(typeof event.amountUsd).toBe('number');
+			}
+		}
+
+		const timestamps = feed.events.map((event) => event.timestamp);
+		const sortedDescending = [...timestamps].sort((a, b) => b - a);
+		expect(timestamps).toEqual(sortedDescending);
+	});
+
+	test('getGlobalClaimFeedV2 pages backwards with the before cursor', async () => {
+		const { state } = getTestSdk();
+		const first = await state.getGlobalClaimFeedV2({ limit: 5 });
+
+		expect(first.events.length).toBeGreaterThan(0);
+
+		const cursor = first.events[first.events.length - 1].timestamp;
+		const next = await state.getGlobalClaimFeedV2({ limit: 5, before: cursor });
+
+		for (const event of next.events) {
+			expect(event.timestamp).toBeLessThan(cursor);
+		}
+	});
+
+	test('getGlobalClaimFeedV2 rejects an out-of-range limit', async () => {
+		const { state } = getTestSdk();
+
+		await expect(state.getGlobalClaimFeedV2({ limit: 0 })).rejects.toThrow();
+		await expect(state.getGlobalClaimFeedV2({ limit: 101 })).rejects.toThrow();
+	});
 });
 


### PR DESCRIPTION
Wraps the new `GET /feed/global-claim/v2` public API endpoint.

Changes:
- `src/types/api.ts` — adds `ForceClaimType`, `GlobalClaimEventV2`, `GetGlobalClaimFeedV2Response`, and `GetGlobalClaimFeedV2Options`. The event's `user` field reuses the existing `TokenLaunchCreator` type.
- `src/services/state.ts` — adds `StateService.getGlobalClaimFeedV2`.
- `tests/services/state.test.ts` — adds coverage for the feed shape and ordering, for `before`-cursor paging, and for limit validation.

The method returns the full `{ events, hasMore }` envelope rather than just the events array, since `hasMore` is what callers need to drive pagination. `limit` is validated client-side to 1–100 to match the endpoint's schema, following the existing `getTokenClaimEvents` precedent in this file.

`amount` stays a string to preserve u64 precision, and is denominated in the base units of the event's own `mint` — not necessarily SOL lamports, which is the point of v2. `amountUsd` is nullable because a claimed mint may have no price quote.

`npm run build` passes. The new tests follow the existing integration-test pattern and need live credentials (`BAGS_API_KEY` and the `BAGS_TEST_*` vars) to run, which weren't available here, so they have not been executed against the live API yet.

Release note: the SDK is published manually with `npm publish`, so a maintainer needs to cut a release after this merges before consumers can use the new method.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4BMRfQYAoBZQCVWvGK56T)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, read-only SDK wrapper around an existing public GET endpoint with client-side limit checks. No auth, writes, or existing method behavior change.
> 
> **Overview**
> Adds `StateService.getGlobalClaimFeedV2`, wrapping `GET /feed/global-claim/v2` so callers can list fee-claim events across all tokens with per-mint amounts, decimals, and optional USD values.
> 
> The method returns `{ events, hasMore }` (not just the array) so pagination can use `hasMore` and a `before` timestamp cursor. Optional filters cover `limit` (client-validated 1–100), amount bounds, and first-claim-only. Forced claims are excluded by the API.
> 
> New types (`GlobalClaimEventV2`, options/response, `ForceClaimType`) live in `api.ts`. Integration tests cover shape/order, backward paging, and limit validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6750302289ec89f834e61c351723a5958aab7599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->