### PR TITLE
fix: align default bagsConfigType with the api default

### DIFF
--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -145,7 +145,7 @@ export function validateAndNormalizeCreateFeeShareConfigParams(params: BagsGetOr
 		tipLamports: tipConfig?.tipLamports,
 		additionalLookupTables: params.additionalLookupTables?.map((lookupTable) => lookupTable.toBase58()),
 		admin: params.admin?.toBase58() ?? undefined,
-		bagsConfigType: params.bagsConfigType ?? BAGS_CONFIG_TYPE.DEFAULT_96_LOCKED,
+		bagsConfigType: params.bagsConfigType ?? BAGS_CONFIG_TYPE.DEFAULT,
 		enableFirstSwapWithMinFee: params.enableFirstSwapWithMinFee,
 	};
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -4,7 +4,8 @@ import { maxKey, sortKeys } from '../src/utils/fee-share';
 import { chunkArray } from '../src/utils/helpers';
 import { getFeeVaultPda } from '../src/utils/fee-claim';
 import { detectImageInputType, prepareImageForFormData } from '../src/utils/image';
-import { isValidUrl, validateAndNormalizeCreateTokenInfoParams } from '../src/utils/validations';
+import { isValidUrl, validateAndNormalizeCreateFeeShareConfigParams, validateAndNormalizeCreateTokenInfoParams } from '../src/utils/validations';
+import { BAGS_CONFIG_TYPE } from '../src/types/api';
 import { BAGS_FEE_SHARE_V2_PROGRAM_ID, BAGS_METEORA_FEE_CLAIMER_VAULT_PDA_SEED } from '../src/constants';
 
 describe('fee-share utils', () => {
@@ -257,6 +258,27 @@ describe('validation utilities', () => {
 		expect(() => validateAndNormalizeCreateTokenInfoParams({ ...base, website: 'not-a-url' } as any)).toThrow(
 			'website must be a valid URL'
 		);
+	});
+
+	test('validateAndNormalizeCreateFeeShareConfigParams defaults bagsConfigType to DEFAULT', () => {
+		const payload = validateAndNormalizeCreateFeeShareConfigParams({
+			payer: new PublicKey(new Uint8Array(32).fill(1)),
+			baseMint: new PublicKey(new Uint8Array(32).fill(2)),
+			feeClaimers: [{ user: new PublicKey(new Uint8Array(32).fill(3)), userBps: 10_000 }],
+		});
+
+		expect(payload.bagsConfigType).toBe(BAGS_CONFIG_TYPE.DEFAULT);
+	});
+
+	test('validateAndNormalizeCreateFeeShareConfigParams keeps an explicit bagsConfigType', () => {
+		const payload = validateAndNormalizeCreateFeeShareConfigParams({
+			payer: new PublicKey(new Uint8Array(32).fill(1)),
+			baseMint: new PublicKey(new Uint8Array(32).fill(2)),
+			feeClaimers: [{ user: new PublicKey(new Uint8Array(32).fill(3)), userBps: 10_000 }],
+			bagsConfigType: BAGS_CONFIG_TYPE.DEFAULT_96_LOCKED,
+		});
+
+		expect(payload.bagsConfigType).toBe(BAGS_CONFIG_TYPE.DEFAULT_96_LOCKED);
 	});
 });
 


### PR DESCRIPTION
## What changed

`validateAndNormalizeCreateFeeShareConfigParams` filled in `BAGS_CONFIG_TYPE.DEFAULT_96_LOCKED` when the caller omitted `bagsConfigType`. It now fills in `BAGS_CONFIG_TYPE.DEFAULT`.

## Why

The backend changed the default on `GetOrCreateFeeShareConfigSchema` for `POST /fee-share/config` from `DEFAULT_96_LOCKED` to `DEFAULT` in bagsfm/bags.backend#1211.

Because the SDK resolves the default client-side and always sends an explicit `bagsConfigType`, the server default never applies to SDK traffic. Without this change, SDK callers who omit `bagsConfigType` would keep getting the 96%-locked config while direct API callers get the standard `DEFAULT` curve — a silent divergence between the SDK and the documented API contract (the public API reference already lists `fa29606e-5e48-4c37-827f-4b03d58ee23d` / Default as the default for this field).

## ⚠️ Behavior change for SDK consumers

This changes the on-chain config created by `config.createBagsFeeShareConfig()` for anyone who does **not** pass `bagsConfigType`:

| | before | after |
|---|---|---|
| omitted `bagsConfigType` | `DEFAULT_96_LOCKED` — 2% base fee, 96% of supply locked, market-cap-decaying post-migration fee, graduates at ~55 SOL | `DEFAULT` — 2% fees pre and post migration, 25% fee compounding, graduates at ~85 SOL |

No types, method signatures, request fields, or response shapes changed, so this is source-compatible — but callers relying on the old implicit default must now pass `bagsConfigType: BAGS_CONFIG_TYPE.DEFAULT_96_LOCKED` explicitly. Worth a minor version bump rather than a patch.

This also affects `bags-cli`, which calls `createBagsFeeShareConfig()` without `bagsConfigType` in both `config create` and `launch`. No CLI code change is needed — it picks up the new default once a release lands.

## Alternative considered

Omitting `bagsConfigType` from the request entirely when the caller omits it, letting the server default apply and removing this class of drift for good. Not done here to keep the change to a single reviewable line; happy to switch if preferred.

## Tests

Added two unit tests in `tests/utils.test.ts` pinning the normalizer's behavior — the resolved default, and that an explicitly passed value is preserved.

- `npx vitest run tests/utils.test.ts` — 19 passed
- `npm run build` — clean

The remaining `tests/services/*` suites hit the live API and were not run here.

## Release

The SDK is published manually with `npm publish`, so a maintainer needs to cut a release after merging before `bags-cli` or any other consumer sees this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wux1qaAhPYXuzayfJi45sj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Silent default change for createBagsFeeShareConfig: omitted bagsConfigType now creates a different on-chain curve (DEFAULT vs 96% locked). Source-compatible, but existing SDK/CLI callers who relied on the implicit default will get different token economics.
> 
> **Overview**
> When `bagsConfigType` is omitted, `validateAndNormalizeCreateFeeShareConfigParams` now fills in `BAGS_CONFIG_TYPE.DEFAULT` instead of `DEFAULT_96_LOCKED`, matching the backend/API default.
> 
> This is a **behavior change** for `createBagsFeeShareConfig()` (and CLI `config create` / `launch`): omitted type previously meant 96% locked / ~55 SOL graduation; it now means the standard DEFAULT curve. Explicit values are unchanged. Callers who still want the locked config must pass `BAGS_CONFIG_TYPE.DEFAULT_96_LOCKED`.
> 
> Adds unit tests for the new default and for preserving an explicit type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2eee66c8e004f36ccd3583864e876fcdb001662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->