### PR TITLE
feat: add damm v2 direct launches listing method

### DIFF
--- a/src/services/token-launch.ts
+++ b/src/services/token-launch.ts
@@ -1,7 +1,13 @@
 import { Commitment, Connection, VersionedTransaction } from '@solana/web3.js';
 import { BaseService } from './base';
 import bs58 from 'bs58';
-import { CreateLaunchTransactionParams, CreateTokenInfoParams, CreateTokenInfoResponse } from '../types/token-launch';
+import {
+	CreateLaunchTransactionParams,
+	CreateTokenInfoParams,
+	CreateTokenInfoResponse,
+	GetDammV2LaunchesParams,
+	GetDammV2LaunchesResponse,
+} from '../types/token-launch';
 import FormData from 'form-data';
 import { prepareImageForFormData } from '../utils/image';
 import { validateAndNormalizeCreateTokenInfoParams } from '../utils/validations';
@@ -82,6 +88,27 @@ export class TokenLaunchService extends BaseService {
 		const response = await this.bagsApiClient.post<CreateTokenInfoResponse>('/token-launch/create-token-info', formData, {
 			headers: {
 				...formData.getHeaders(),
+			},
+		});
+
+		return response;
+	}
+
+	/**
+	 * Get confirmed DAMM v2 direct launches
+	 *
+	 * Newest-first, paginated list of confirmed DAMM v2 direct launches, optionally filtered
+	 * by quote mint.
+	 *
+	 * @param params Pagination and filter options
+	 * @returns The page of launches
+	 */
+	async getDammV2Launches(params: GetDammV2LaunchesParams = {}): Promise<GetDammV2LaunchesResponse> {
+		const response = await this.bagsApiClient.get<GetDammV2LaunchesResponse>('/token-launch/damm-v2/launches', {
+			params: {
+				limit: params.limit,
+				quoteMint: params.quoteMint?.toBase58(),
+				cursor: params.cursor,
 			},
 		});
 

--- a/src/types/token-launch.ts
+++ b/src/types/token-launch.ts
@@ -75,6 +75,26 @@ export interface BagsLaunchPadTokenLaunch {
 	updatedAt: string;
 }
 
+export type DammV2DirectLaunch = Omit<BagsLaunchPadTokenLaunch, 'userId'>;
+
+export interface GetDammV2LaunchesParams {
+	/** Page size, 1-100. Defaults to 20 server-side. */
+	limit?: number;
+	/** Base58 quote mint to filter launches by. */
+	quoteMint?: PublicKey;
+	/** Cursor from a previous response's `nextCursor`. Omit for the first page. */
+	cursor?: string;
+}
+
+export interface GetDammV2LaunchesResponse {
+	/** Confirmed DAMM v2 direct launches, newest first. */
+	launches: DammV2DirectLaunch[];
+	/** True when another page of results exists. */
+	hasMore: boolean;
+	/** Cursor to pass as `cursor` to fetch the next page, or null on the last page. */
+	nextCursor: string | null;
+}
+
 export interface CreateTokenInfoResponse {
 	tokenMint: string;
 	tokenMetadata: string;

--- a/src/types/token-launch.ts
+++ b/src/types/token-launch.ts
@@ -71,6 +71,8 @@ export interface BagsLaunchPadTokenLaunch {
 	launchWallet: string | null;
 	launchSignature: string | null;
 	uri: string | null;
+	/** DBC launch mode. `null` when the token has no DBC config (pre-launch or DAMM v2 direct). */
+	bagsConfigType: (typeof BAGS_CONFIG_TYPE)[keyof typeof BAGS_CONFIG_TYPE] | null;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/tests/services/token-launch.test.ts
+++ b/tests/services/token-launch.test.ts
@@ -40,5 +40,19 @@ describe('TokenLaunchService integration', () => {
 
 		expect(transaction).toBeInstanceOf(VersionedTransaction);
 	});
+
+	test('getDammV2Launches returns a paginated page of launches', async () => {
+		const sdk = getTestSdk();
+		const page = await sdk.tokenLaunch.getDammV2Launches({ limit: 5 });
+
+		expect(Array.isArray(page.launches)).toBe(true);
+		expect(page.launches.length).toBeLessThanOrEqual(5);
+		expect(typeof page.hasMore).toBe('boolean');
+
+		if (page.launches.length > 0) {
+			const [first] = page.launches;
+			expect(() => new PublicKey(first.tokenMint)).not.toThrow();
+		}
+	});
 });
 


### PR DESCRIPTION
Adds `tokenLaunch.getDammV2Launches(params)`, wrapping the new public `GET /token-launch/damm-v2/launches` endpoint: a newest-first, paginated list of confirmed DAMM v2 direct launches with an optional `quoteMint` filter.

- `DammV2DirectLaunch` type in `src/types/token-launch.ts` (mirrors the existing `BagsLaunchPadTokenLaunch` shape minus `userId`, consistent with other public launch records)
- `GetDammV2LaunchesParams` / `GetDammV2LaunchesResponse` types for the request/response shape
- `getDammV2Launches` method on `TokenLaunchService`
- Integration test in `tests/services/token-launch.test.ts`

The SDK is published manually with `npm publish` — a maintainer needs to release this before the CLI can depend on it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEN6aiXv52Q8t24RxzTTiA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only SDK wrapper around a public GET endpoint with types and an integration test; no auth, signing, or mutation changes.
> 
> **Overview**
> Adds `tokenLaunch.getDammV2Launches()` to fetch a newest-first, cursor-paginated list of confirmed DAMM v2 direct launches, optionally filtered by `quoteMint`.
> 
> Also adds `bagsConfigType` on `BagsLaunchPadTokenLaunch` (nullable for pre-launch / DAMM v2 direct) and a `DammV2DirectLaunch` type that omits `userId`. Includes a basic integration test for pagination shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a31519e4368ea9736a22ea0c7dc60b146442af14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->