### PR TITLE
feat: add get token launch method

### DIFF
--- a/src/services/token-launch.ts
+++ b/src/services/token-launch.ts
@@ -1,7 +1,12 @@
-import { Commitment, Connection, VersionedTransaction } from '@solana/web3.js';
+import { Commitment, Connection, PublicKey, VersionedTransaction } from '@solana/web3.js';
 import { BaseService } from './base';
 import bs58 from 'bs58';
-import { CreateLaunchTransactionParams, CreateTokenInfoParams, CreateTokenInfoResponse } from '../types/token-launch';
+import {
+	CreateLaunchTransactionParams,
+	CreateTokenInfoParams,
+	CreateTokenInfoResponse,
+	GetTokenLaunchResponse,
+} from '../types/token-launch';
 import FormData from 'form-data';
 import { prepareImageForFormData } from '../utils/image';
 import { validateAndNormalizeCreateTokenInfoParams } from '../utils/validations';
@@ -82,6 +87,22 @@ export class TokenLaunchService extends BaseService {
 		const response = await this.bagsApiClient.post<CreateTokenInfoResponse>('/token-launch/create-token-info', formData, {
 			headers: {
 				...formData.getHeaders(),
+			},
+		});
+
+		return response;
+	}
+
+	/**
+	 * Get a token launch by mint
+	 *
+	 * @param tokenMint The token mint to look up
+	 * @returns The token launch record, or null if no launch exists for the mint
+	 */
+	async getTokenLaunch(tokenMint: PublicKey): Promise<GetTokenLaunchResponse> {
+		const response = await this.bagsApiClient.get<GetTokenLaunchResponse>('/token-launch', {
+			params: {
+				tokenMint: tokenMint.toBase58(),
 			},
 		});
 

--- a/src/types/token-launch.ts
+++ b/src/types/token-launch.ts
@@ -70,10 +70,56 @@ export interface BagsLaunchPadTokenLaunch {
 	status: TokenLaunchStatus;
 	launchWallet: string | null;
 	launchSignature: string | null;
+	/** Launch transaction account keys. */
+	accountKeys: string[] | null;
+	/** Number of required launch transaction signers. */
+	numRequiredSigners: number | null;
+	/** Creator fee in basis points. */
+	creatorFeeBps: number | null;
 	uri: string | null;
+	/** Meteora DBC pool address. */
+	dbcPoolKey: string | null;
+	/** Meteora DBC config address. */
+	dbcConfigKey: string | null;
+	/** DBC launch mode. `null` when the token has no `dbcConfigKey` (pre-launch or DAMM v2 direct). */
+	bagsConfigType: (typeof BAGS_CONFIG_TYPE)[keyof typeof BAGS_CONFIG_TYPE] | null;
+	/** DAMM v2 pool address. */
+	dammV2PoolKey: string | null;
+	/** Launch mechanism; `null` means legacy DBC. */
+	launchType: string | null;
+	/** DAMM v2 direct quote mint. */
+	quoteMint: string | null;
+	/** Treasury position NFT mint. */
+	dammV2TreasuryPositionNftMint: string | null;
+	/** Fee claimer position NFT mint. */
+	dammV2FeeClaimerPositionNftMint: string | null;
+	/** Fee claimer wallet. */
+	feeClaimerWallet: string | null;
+	/** Address lookup table used by the launch. */
+	dammV2LookupTable: string | null;
+	/** DAMM v2 position custody account. */
+	dammV2PositionCustody: string | null;
+	/** Authority for the DAMM v2 custody account. */
+	dammV2CustodyAuthority: string | null;
+	/** Optional custody partner wallet. */
+	dammV2Partner: string | null;
+	/** Optional custody deployer wallet. */
+	dammV2Deployer: string | null;
+	/** Deployer fee collection mode. */
+	dammV2DeployerFeeCollectionMode: number | null;
+	/** Deployer platform fee in basis points. */
+	dammV2DeployerPlatformBps: number | null;
+	/** Deployer claimer fee in basis points. */
+	dammV2DeployerClaimersBps: number | null;
 	createdAt: string;
 	updatedAt: string;
 }
+
+export type TokenLaunchResponseItem = Omit<BagsLaunchPadTokenLaunch, 'userId'>;
+
+export type GetTokenLaunchResponse = TokenLaunchResponseItem | null;
+
+export type GetTokenLaunchBulkResponse = Array<TokenLaunchResponseItem | null>;
 
 export interface CreateTokenInfoResponse {
 	tokenMint: string;

--- a/tests/services/token-launch.test.ts
+++ b/tests/services/token-launch.test.ts
@@ -40,5 +40,20 @@ describe('TokenLaunchService integration', () => {
 
 		expect(transaction).toBeInstanceOf(VersionedTransaction);
 	});
+
+	test('getTokenLaunch returns the token launch for a known mint', async () => {
+		const sdk = getTestSdk();
+		const tokenLaunch = await sdk.tokenLaunch.getTokenLaunch(new PublicKey(tokenInfoResponse.tokenMint));
+
+		expect(tokenLaunch).not.toBeNull();
+		expect(tokenLaunch?.tokenMint).toBe(tokenInfoResponse.tokenMint);
+	});
+
+	test('getTokenLaunch returns null for an unknown mint', async () => {
+		const sdk = getTestSdk();
+		const tokenLaunch = await sdk.tokenLaunch.getTokenLaunch(PublicKey.unique());
+
+		expect(tokenLaunch).toBeNull();
+	});
 });
 


### PR DESCRIPTION
Adds `tokenLaunch.getTokenLaunch(tokenMint)`, wrapping the new public `GET /token-launch` endpoint: fetch a single token launch record by mint, or `null` if none exists.

- Extends `BagsLaunchPadTokenLaunch` in `src/types/token-launch.ts` with the fields the backend actually returns beyond the current subset (DBC/DAMM v2 pool and config fields, `bagsConfigType`, launch transaction metadata) so the type matches the real response shape.
- Adds `TokenLaunchResponseItem` (`Omit<BagsLaunchPadTokenLaunch, 'userId'>`), `GetTokenLaunchResponse`, and `GetTokenLaunchBulkResponse` types.
- Adds `getTokenLaunch` on `TokenLaunchService`.
- Adds integration tests in `tests/services/token-launch.test.ts`.

The SDK is published manually with `npm publish` — a maintainer needs to release this before consumers can use it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGRrRXret9Sxez7XZGA7gM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only SDK wrapper around GET /token-launch plus additive type fields. No auth, writes, or transaction-building changes.
> 
> **Overview**
> Adds `tokenLaunch.getTokenLaunch(tokenMint)` so clients can look up a single launch via `GET /token-launch`, returning the record or `null` if the mint has no launch.
> 
> **`BagsLaunchPadTokenLaunch`** now includes the DBC/DAMM v2 pool, config, custody, fee, and launch-tx metadata the API already returns. `TokenLaunchResponseItem` omits `userId` for this endpoint. `GetTokenLaunchBulkResponse` is typed but unused.
> 
> Integration tests cover a known mint after `createTokenInfoAndMetadata` and a random mint that should be null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ee83537bc9ac071cb937c3ad14266bea17cc779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->