### PR TITLE
feat: add get token launch bulk method

### DIFF
--- a/src/services/token-launch.ts
+++ b/src/services/token-launch.ts
@@ -1,7 +1,12 @@
-import { Commitment, Connection, VersionedTransaction } from '@solana/web3.js';
+import { Commitment, Connection, PublicKey, VersionedTransaction } from '@solana/web3.js';
 import { BaseService } from './base';
 import bs58 from 'bs58';
-import { CreateLaunchTransactionParams, CreateTokenInfoParams, CreateTokenInfoResponse } from '../types/token-launch';
+import {
+	CreateLaunchTransactionParams,
+	CreateTokenInfoParams,
+	CreateTokenInfoResponse,
+	GetTokenLaunchBulkResponse,
+} from '../types/token-launch';
 import FormData from 'form-data';
 import { prepareImageForFormData } from '../utils/image';
 import { validateAndNormalizeCreateTokenInfoParams } from '../utils/validations';
@@ -83,6 +88,23 @@ export class TokenLaunchService extends BaseService {
 			headers: {
 				...formData.getHeaders(),
 			},
+		});
+
+		return response;
+	}
+
+	/**
+	 * Get token launches in bulk
+	 *
+	 * Fetches token launch records for up to 100 token mints in one request. Results
+	 * preserve input order, with `null` for a mint that has no launch record.
+	 *
+	 * @param tokenMints The token mints to look up (1-100 unique keys)
+	 * @returns The token launch records, in the same order as `tokenMints`
+	 */
+	async getTokenLaunchesBulk(tokenMints: PublicKey[]): Promise<GetTokenLaunchBulkResponse> {
+		const response = await this.bagsApiClient.post<GetTokenLaunchBulkResponse>('/token-launch/bulk', {
+			tokenMints: tokenMints.map((tokenMint) => tokenMint.toBase58()),
 		});
 
 		return response;

--- a/src/types/token-launch.ts
+++ b/src/types/token-launch.ts
@@ -70,10 +70,56 @@ export interface BagsLaunchPadTokenLaunch {
 	status: TokenLaunchStatus;
 	launchWallet: string | null;
 	launchSignature: string | null;
+	/** Launch transaction account keys. */
+	accountKeys: string[] | null;
+	/** Number of required launch transaction signers. */
+	numRequiredSigners: number | null;
+	/** Creator fee in basis points. */
+	creatorFeeBps: number | null;
 	uri: string | null;
+	/** Meteora DBC pool address. */
+	dbcPoolKey: string | null;
+	/** Meteora DBC config address. */
+	dbcConfigKey: string | null;
+	/** DBC launch mode. `null` when the token has no `dbcConfigKey` (pre-launch or DAMM v2 direct). */
+	bagsConfigType: (typeof BAGS_CONFIG_TYPE)[keyof typeof BAGS_CONFIG_TYPE] | null;
+	/** DAMM v2 pool address. */
+	dammV2PoolKey: string | null;
+	/** Launch mechanism; `null` means legacy DBC. */
+	launchType: string | null;
+	/** DAMM v2 direct quote mint. */
+	quoteMint: string | null;
+	/** Treasury position NFT mint. */
+	dammV2TreasuryPositionNftMint: string | null;
+	/** Fee claimer position NFT mint. */
+	dammV2FeeClaimerPositionNftMint: string | null;
+	/** Fee claimer wallet. */
+	feeClaimerWallet: string | null;
+	/** Address lookup table used by the launch. */
+	dammV2LookupTable: string | null;
+	/** DAMM v2 position custody account. */
+	dammV2PositionCustody: string | null;
+	/** Authority for the DAMM v2 custody account. */
+	dammV2CustodyAuthority: string | null;
+	/** Optional custody partner wallet. */
+	dammV2Partner: string | null;
+	/** Optional custody deployer wallet. */
+	dammV2Deployer: string | null;
+	/** Deployer fee collection mode. */
+	dammV2DeployerFeeCollectionMode: number | null;
+	/** Deployer platform fee in basis points. */
+	dammV2DeployerPlatformBps: number | null;
+	/** Deployer claimer fee in basis points. */
+	dammV2DeployerClaimersBps: number | null;
 	createdAt: string;
 	updatedAt: string;
 }
+
+export type TokenLaunchResponseItem = Omit<BagsLaunchPadTokenLaunch, 'userId'>;
+
+export type GetTokenLaunchResponse = TokenLaunchResponseItem | null;
+
+export type GetTokenLaunchBulkResponse = Array<TokenLaunchResponseItem | null>;
 
 export interface CreateTokenInfoResponse {
 	tokenMint: string;

--- a/tests/services/token-launch.test.ts
+++ b/tests/services/token-launch.test.ts
@@ -40,5 +40,18 @@ describe('TokenLaunchService integration', () => {
 
 		expect(transaction).toBeInstanceOf(VersionedTransaction);
 	});
+
+	test('getTokenLaunchesBulk preserves order and returns null for unknown mints', async () => {
+		const sdk = getTestSdk();
+		const unknownMint = PublicKey.unique();
+		const tokenLaunches = await sdk.tokenLaunch.getTokenLaunchesBulk([
+			new PublicKey(tokenInfoResponse.tokenMint),
+			unknownMint,
+		]);
+
+		expect(tokenLaunches).toHaveLength(2);
+		expect(tokenLaunches[0]?.tokenMint).toBe(tokenInfoResponse.tokenMint);
+		expect(tokenLaunches[1]).toBeNull();
+	});
 });
 


### PR DESCRIPTION
Adds `tokenLaunch.getTokenLaunchesBulk(tokenMints)`, wrapping the new public `POST /token-launch/bulk` endpoint: fetch up to 100 token launch records by mint in one request, preserving input order with `null` for mints that have no record.

- Extends `BagsLaunchPadTokenLaunch` in `src/types/token-launch.ts` with the fields the backend actually returns beyond the current subset (DBC/DAMM v2 pool and config fields, `bagsConfigType`, launch transaction metadata) so the type matches the real response shape.
- Adds `TokenLaunchResponseItem` (`Omit<BagsLaunchPadTokenLaunch, 'userId'>`), `GetTokenLaunchResponse`, and `GetTokenLaunchBulkResponse` types. Shared with the new `GET /token-launch` SDK PR.
- Adds `getTokenLaunchesBulk` on `TokenLaunchService`.
- Adds an integration test in `tests/services/token-launch.test.ts`.

The SDK is published manually with `npm publish` — a maintainer needs to release this before consumers can use it.

Note: this PR and the `GET /token-launch` SDK PR both touch `BagsLaunchPadTokenLaunch` in `src/types/token-launch.ts` — whichever merges second will need a quick rebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGRrRXret9Sxez7XZGA7gM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin SDK wrapper around an existing read-only API; no auth, signing, or data-mutation changes.
> 
> **Overview**
> Adds `getTokenLaunchesBulk` on `TokenLaunchService` so clients can fetch up to 100 launch records in one `POST /token-launch/bulk` call.
> 
> Mints are sent as base58 strings. Results keep input order, with `null` for mints that have no launch. An integration test covers a known mint plus an unknown mint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5361f318edcd601bfa17219e506161b24c9313e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->