### PR TITLE
feat: add get damm v2 supported quote tokens method

### DIFF
--- a/src/services/token-launch.ts
+++ b/src/services/token-launch.ts
@@ -1,7 +1,12 @@
 import { Commitment, Connection, VersionedTransaction } from '@solana/web3.js';
 import { BaseService } from './base';
 import bs58 from 'bs58';
-import { CreateLaunchTransactionParams, CreateTokenInfoParams, CreateTokenInfoResponse } from '../types/token-launch';
+import {
+	CreateLaunchTransactionParams,
+	CreateTokenInfoParams,
+	CreateTokenInfoResponse,
+	DammV2SupportedQuoteToken,
+} from '../types/token-launch';
 import FormData from 'form-data';
 import { prepareImageForFormData } from '../utils/image';
 import { validateAndNormalizeCreateTokenInfoParams } from '../utils/validations';
@@ -86,5 +91,20 @@ export class TokenLaunchService extends BaseService {
 		});
 
 		return response;
+	}
+
+	/**
+	 * Get DAMM v2 supported quote tokens
+	 *
+	 * Every quote mint currently usable for DAMM v2 direct launches.
+	 *
+	 * @returns The supported quote tokens
+	 */
+	async getDammV2SupportedQuoteTokens(): Promise<DammV2SupportedQuoteToken[]> {
+		const response = await this.bagsApiClient.get<{ tokens: DammV2SupportedQuoteToken[] }>(
+			'/token-launch/damm-v2/supported-quote-tokens',
+		);
+
+		return response.tokens;
 	}
 }

--- a/src/types/token-launch.ts
+++ b/src/types/token-launch.ts
@@ -131,3 +131,19 @@ export type NormalizedCreateFeeShareConfigParams = {
 	bagsConfigType?: (typeof BAGS_CONFIG_TYPE)[keyof typeof BAGS_CONFIG_TYPE];
 	enableFirstSwapWithMinFee?: boolean;
 };
+
+export interface DammV2SupportedQuoteToken {
+	/** Quote mint public key. */
+	mint: string;
+	/** Token program that owns the mint (`Tokenkeg...` or `TokenzQd...`). */
+	tokenProgram: string;
+	decimals: number;
+	/** Token 2022 on-chain name, or `null` when the mint has no TokenMetadata extension. */
+	name: string | null;
+	/** Token 2022 on-chain symbol, or `null` when the mint has no TokenMetadata extension. */
+	symbol: string | null;
+	/** Token 2022 metadata JSON URI, or `null` when the mint has no TokenMetadata extension. */
+	uri: string | null;
+	/** Token image URL, or `null` when neither a CDN image nor an image URI is set. */
+	image: string | null;
+}

--- a/tests/services/token-launch.test.ts
+++ b/tests/services/token-launch.test.ts
@@ -40,5 +40,17 @@ describe('TokenLaunchService integration', () => {
 
 		expect(transaction).toBeInstanceOf(VersionedTransaction);
 	});
+
+	test('getDammV2SupportedQuoteTokens returns a list of quote tokens', async () => {
+		const sdk = getTestSdk();
+		const tokens = await sdk.tokenLaunch.getDammV2SupportedQuoteTokens();
+
+		expect(Array.isArray(tokens)).toBe(true);
+
+		if (tokens.length > 0) {
+			const [first] = tokens;
+			expect(() => new PublicKey(first.mint)).not.toThrow();
+		}
+	});
 });
 


### PR DESCRIPTION
Adds `tokenLaunch.getDammV2SupportedQuoteTokens()`, wrapping the new public `GET /token-launch/damm-v2/supported-quote-tokens` endpoint: every quote mint currently usable for DAMM v2 direct launches.

- Adds `DammV2SupportedQuoteToken` type in `src/types/token-launch.ts`.
- Adds `getDammV2SupportedQuoteTokens` on `TokenLaunchService`.
- Adds an integration test in `tests/services/token-launch.test.ts`.

The SDK is published manually with `npm publish` — a maintainer needs to release this before consumers can use it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGRrRXret9Sxez7XZGA7gM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only SDK wrapper around a new public GET endpoint; no auth, write, or transaction-building changes.
> 
> **Overview**
> Adds `tokenLaunch.getDammV2SupportedQuoteTokens()`, a thin GET wrapper for `/token-launch/damm-v2/supported-quote-tokens` so clients can list every quote mint currently usable for DAMM v2 direct launches.
> 
> Introduces the `DammV2SupportedQuoteToken` type (mint, token program, decimals, and optional Token-2022 metadata/image fields) and an integration test that checks the response is an array of valid mints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ae61a48265a6b74e4c9cdc71afeb02c962a920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->