### PR TITLE
feat: add get damm v2 vault claimables method

### DIFF
--- a/src/services/token-launch.ts
+++ b/src/services/token-launch.ts
@@ -1,7 +1,12 @@
-import { Commitment, Connection, VersionedTransaction } from '@solana/web3.js';
+import { Commitment, Connection, PublicKey, VersionedTransaction } from '@solana/web3.js';
 import { BaseService } from './base';
 import bs58 from 'bs58';
-import { CreateLaunchTransactionParams, CreateTokenInfoParams, CreateTokenInfoResponse } from '../types/token-launch';
+import {
+	CreateLaunchTransactionParams,
+	CreateTokenInfoParams,
+	CreateTokenInfoResponse,
+	DammV2VaultClaimable,
+} from '../types/token-launch';
 import FormData from 'form-data';
 import { prepareImageForFormData } from '../utils/image';
 import { validateAndNormalizeCreateTokenInfoParams } from '../utils/validations';
@@ -86,5 +91,26 @@ export class TokenLaunchService extends BaseService {
 		});
 
 		return response;
+	}
+
+	/**
+	 * Get DAMM v2 vault claimables
+	 *
+	 * Every non-empty partner/deployer aggregate vault balance for a wallet.
+	 *
+	 * @param wallet The partner/deployer wallet to look up
+	 * @returns The claimable vault balances
+	 */
+	async getDammV2VaultClaimables(wallet: PublicKey): Promise<DammV2VaultClaimable[]> {
+		const response = await this.bagsApiClient.get<{ vaults: DammV2VaultClaimable[] }>(
+			'/token-launch/damm-v2/vault-claimables',
+			{
+				params: {
+					wallet: wallet.toBase58(),
+				},
+			},
+		);
+
+		return response.vaults;
 	}
 }

--- a/src/types/token-launch.ts
+++ b/src/types/token-launch.ts
@@ -131,3 +131,22 @@ export type NormalizedCreateFeeShareConfigParams = {
 	bagsConfigType?: (typeof BAGS_CONFIG_TYPE)[keyof typeof BAGS_CONFIG_TYPE];
 	enableFirstSwapWithMinFee?: boolean;
 };
+
+export type DammV2VaultKind = 'partner' | 'deployer';
+
+export interface DammV2VaultClaimable {
+	/** Which aggregate vault this balance belongs to. */
+	kind: DammV2VaultKind;
+	/** Public key of the partner/deployer wallet. */
+	wallet: string;
+	/** Public key of the quote mint this vault is denominated in. */
+	quoteMint: string;
+	/** Decimals of the quote mint. */
+	quoteDecimals: number;
+	/** Public key of the vault's associated token account. */
+	vaultAta: string;
+	/** Claimable balance in quote mint base units. */
+	claimableAmount: number;
+	/** Claimable balance in whole quote tokens. */
+	claimableDisplayAmount: number;
+}

--- a/tests/services/token-launch.test.ts
+++ b/tests/services/token-launch.test.ts
@@ -40,5 +40,12 @@ describe('TokenLaunchService integration', () => {
 
 		expect(transaction).toBeInstanceOf(VersionedTransaction);
 	});
+
+	test('getDammV2VaultClaimables returns an array of vault balances', async () => {
+		const sdk = getTestSdk();
+		const vaults = await sdk.tokenLaunch.getDammV2VaultClaimables(testEnv.launchWallet);
+
+		expect(Array.isArray(vaults)).toBe(true);
+	});
 });
 


### PR DESCRIPTION
Adds `tokenLaunch.getDammV2VaultClaimables(wallet)`, wrapping the new public `GET /token-launch/damm-v2/vault-claimables` endpoint: every non-empty partner/deployer aggregate vault balance for a wallet.

- Adds `DammV2VaultKind` and `DammV2VaultClaimable` types in `src/types/token-launch.ts`. Shared with the upcoming `claim-vault` SDK PR.
- Adds `getDammV2VaultClaimables` on `TokenLaunchService`.
- Adds an integration test in `tests/services/token-launch.test.ts`.

The SDK is published manually with `npm publish` — a maintainer needs to release this before consumers can use it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGRrRXret9Sxez7XZGA7gM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only SDK wrapper around an existing GET endpoint; no auth, signing, or claim-transaction changes.
> 
> **Overview**
> Adds `tokenLaunch.getDammV2VaultClaimables(wallet)` so partners/deployers can list non-empty DAMM v2 aggregate vault balances for a wallet.
> 
> The method wraps `GET /token-launch/damm-v2/vault-claimables` and returns `DammV2VaultClaimable[]`. An integration test checks that the call returns an array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb424b57bd11607a29b0d2af39a8d8b8b5e1cd66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->