### PR TITLE
feat: add create damm v2 launch transaction method

### DIFF
--- a/src/services/token-launch.ts
+++ b/src/services/token-launch.ts
@@ -1,7 +1,13 @@
 import { Commitment, Connection, VersionedTransaction } from '@solana/web3.js';
 import { BaseService } from './base';
 import bs58 from 'bs58';
-import { CreateLaunchTransactionParams, CreateTokenInfoParams, CreateTokenInfoResponse } from '../types/token-launch';
+import {
+	CreateDammV2LaunchTransactionParams,
+	CreateDammV2LaunchTransactionResponse,
+	CreateLaunchTransactionParams,
+	CreateTokenInfoParams,
+	CreateTokenInfoResponse,
+} from '../types/token-launch';
 import FormData from 'form-data';
 import { prepareImageForFormData } from '../utils/image';
 import { validateAndNormalizeCreateTokenInfoParams } from '../utils/validations';
@@ -83,6 +89,31 @@ export class TokenLaunchService extends BaseService {
 			headers: {
 				...formData.getHeaders(),
 			},
+		});
+
+		return response;
+	}
+
+	/**
+	 * Create a DAMM v2 direct launch transaction bundle
+	 *
+	 * Builds the partially-signed transaction bundle that launches a token previously
+	 * registered via `createTokenInfoAndMetadata` straight into a single-sided DAMM v2
+	 * customizable pool (no DBC bonding curve, no migration). Every transaction in the
+	 * bundle must be co-signed by `params.wallet` before submission.
+	 *
+	 * @param params The parameters for the DAMM v2 direct launch
+	 * @returns The transaction bundle and launch details
+	 */
+	async createDammV2LaunchTransaction(params: CreateDammV2LaunchTransactionParams): Promise<CreateDammV2LaunchTransactionResponse> {
+		const response = await this.bagsApiClient.post<CreateDammV2LaunchTransactionResponse>('/token-launch/damm-v2/create-transaction', {
+			ipfs: params.metadataUrl,
+			tokenMint: params.tokenMint.toBase58(),
+			wallet: params.wallet.toBase58(),
+			quoteMint: params.quoteMint.toBase58(),
+			feeClaimerWallet: params.feeClaimerWallet?.toBase58(),
+			initialBuyQuoteAmount: params.initialBuyQuoteAmount,
+			partner: params.partner?.toBase58(),
 		});
 
 		return response;

--- a/src/types/token-launch.ts
+++ b/src/types/token-launch.ts
@@ -21,6 +21,53 @@ export interface CreateLaunchTransactionParams {
 	tipConfig?: TransactionTipConfig;
 }
 
+export interface CreateDammV2LaunchTransactionParams {
+	/** Metadata URI from `createTokenInfoAndMetadata`. */
+	metadataUrl: string;
+	/** Mint from `createTokenInfoAndMetadata`. */
+	tokenMint: PublicKey;
+	/** Launch wallet; fee payer and signer of every transaction in the bundle. */
+	wallet: PublicKey;
+	/** Badged quote mint (see `getDammV2SupportedQuoteTokens`). */
+	quoteMint: PublicKey;
+	/** Receives the 50% fee position NFT; defaults to `wallet`. */
+	feeClaimerWallet?: PublicKey;
+	/** Initial buy amount in quote mint base units; `wallet` must already hold this quote balance at build time. */
+	initialBuyQuoteAmount?: number;
+	/** Existing PartnerConfig wallet to attach to the custody (its global bps applies). */
+	partner?: PublicKey;
+}
+
+export type DammV2LaunchTransactionBundleItemType = 'LUT_SETUP' | 'CREATE_TOKEN' | 'LAUNCH' | 'LUT_DEACTIVATE' | 'LUT_CLOSE';
+
+export interface DammV2LaunchTransactionBundleItem {
+	/** Which step of the launch bundle this transaction performs. */
+	type: DammV2LaunchTransactionBundleItemType;
+	/** Base58-encoded serialized transaction. */
+	transaction: string;
+}
+
+export interface DammV2LaunchDetails {
+	tokenMint: string;
+	quoteMint: string;
+	quoteTokenProgram: string;
+	pool: string;
+	treasuryPositionNftMint: string;
+	feeClaimerPositionNftMint: string;
+	feeClaimerWallet: string;
+	lookupTable: string;
+	positionCustody: string;
+	custodyAuthority: string;
+	launchPriceQuotePerToken: number;
+	impliedLaunchFdvUsd: number;
+}
+
+export interface CreateDammV2LaunchTransactionResponse {
+	/** Ordered transaction bundle; each must be co-signed by `wallet` before submission. */
+	transactions: DammV2LaunchTransactionBundleItem[];
+	launch: DammV2LaunchDetails;
+}
+
 /**
  * Parameters for creating token info and (optionally) uploading metadata.
  *

--- a/tests/services/token-launch.test.ts
+++ b/tests/services/token-launch.test.ts
@@ -40,5 +40,19 @@ describe('TokenLaunchService integration', () => {
 
 		expect(transaction).toBeInstanceOf(VersionedTransaction);
 	});
+
+	test('createDammV2LaunchTransaction returns a launch transaction bundle', async () => {
+		const sdk = getTestSdk();
+		const result = await sdk.tokenLaunch.createDammV2LaunchTransaction({
+			metadataUrl: tokenInfoResponse.tokenMetadata,
+			tokenMint: new PublicKey(tokenInfoResponse.tokenMint),
+			wallet: testEnv.launchWallet,
+			quoteMint: testEnv.quoteMint,
+		});
+
+		expect(Array.isArray(result.transactions)).toBe(true);
+		expect(result.transactions.length).toBeGreaterThan(0);
+		expect(result.launch.tokenMint).toBe(tokenInfoResponse.tokenMint);
+	});
 });
 


### PR DESCRIPTION
Adds `tokenLaunch.createDammV2LaunchTransaction(params)`, wrapping the new public `POST /token-launch/damm-v2/create-transaction` endpoint: builds the partially-signed transaction bundle for a DAMM v2 direct launch (no DBC bonding curve, no migration — the pool is the market from block one).

- Adds `CreateDammV2LaunchTransactionParams`, `DammV2LaunchTransactionBundleItem`, `DammV2LaunchDetails`, and `CreateDammV2LaunchTransactionResponse` types in `src/types/token-launch.ts`.
- Adds `createDammV2LaunchTransaction` on `TokenLaunchService`. Bundle transactions are returned as base58 strings with a `type` tag (`LUT_SETUP`/`CREATE_TOKEN`/`LAUNCH`/`LUT_DEACTIVATE`/`LUT_CLOSE`) rather than deserialized — the bundle mixes versioned and legacy transactions with a specific co-sign/submission order, so callers need the raw encoding to handle each step correctly (mirrors the backend's own documented client-usage pattern).
- Adds an integration test in `tests/services/token-launch.test.ts` that builds (but does not submit) a bundle against the existing test token/wallet fixtures.

Only accepts the fields the backend's Zod schema actually validates (`ipfs`/`metadataUrl`, `tokenMint`, `wallet`, `quoteMint`, optional `feeClaimerWallet`/`initialBuyQuoteAmount`/`partner`) — no `deployer` param, since that's server-side only despite an older backend doc comment suggesting otherwise.

The SDK is published manually with `npm publish` — a maintainer needs to release this before consumers can use it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGRrRXret9Sxez7XZGA7gM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Thin client wrapper around a new launch endpoint; no auth changes, but it is a financial token-launch path and returns unsigned-looking bundle txs that callers must co-sign correctly.
> 
> **Overview**
> Adds `createDammV2LaunchTransaction` so callers can build a **DAMM v2 direct launch** (single-sided pool, no DBC/migration) after `createTokenInfoAndMetadata`.
> 
> The method posts to `/token-launch/damm-v2/create-transaction` and returns an ordered, typed bundle of **base58-encoded** txs (`LUT_SETUP` / `CREATE_TOKEN` / `LAUNCH` / `LUT_DEACTIVATE` / `LUT_CLOSE`) plus launch details. Unlike `createLaunchTransaction`, txs are not deserialized so mixed versioned/legacy steps can be co-signed in order.
> 
> Optional params: `feeClaimerWallet`, `initialBuyQuoteAmount`, `partner`. Integration test builds a bundle against existing fixtures without submitting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf09acebf9e03817f9c2e523de61f64c71522e84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->