### PR TITLE
feat: add claim damm v2 vault method

### DIFF
--- a/src/services/token-launch.ts
+++ b/src/services/token-launch.ts
@@ -1,7 +1,14 @@
 import { Commitment, Connection, VersionedTransaction } from '@solana/web3.js';
 import { BaseService } from './base';
 import bs58 from 'bs58';
-import { CreateLaunchTransactionParams, CreateTokenInfoParams, CreateTokenInfoResponse } from '../types/token-launch';
+import {
+	ClaimDammV2VaultParams,
+	ClaimDammV2VaultResponse,
+	ClaimDammV2VaultWireResponse,
+	CreateLaunchTransactionParams,
+	CreateTokenInfoParams,
+	CreateTokenInfoResponse,
+} from '../types/token-launch';
 import FormData from 'form-data';
 import { prepareImageForFormData } from '../utils/image';
 import { validateAndNormalizeCreateTokenInfoParams } from '../utils/validations';
@@ -86,5 +93,31 @@ export class TokenLaunchService extends BaseService {
 		});
 
 		return response;
+	}
+
+	/**
+	 * Claim a DAMM v2 partner/deployer vault
+	 *
+	 * Sweeps the caller's partner or deployer aggregate vault for a quote mint to their
+	 * wallet. The returned transaction is gas-sponsored: the gas sponsor is the fee payer,
+	 * and `params.wallet` only needs to co-sign as the authorizer. Throws if the vault is
+	 * empty ("Nothing to claim").
+	 *
+	 * @param params The vault to claim
+	 * @returns The claim transaction and the claimable balance it sweeps
+	 */
+	async claimDammV2Vault(params: ClaimDammV2VaultParams): Promise<ClaimDammV2VaultResponse> {
+		const response = await this.bagsApiClient.post<ClaimDammV2VaultWireResponse>('/token-launch/damm-v2/claim-vault', {
+			kind: params.kind,
+			wallet: params.wallet.toBase58(),
+			quoteMint: params.quoteMint.toBase58(),
+		});
+
+		const decodedTransaction = bs58.decode(response.transaction);
+
+		return {
+			transaction: VersionedTransaction.deserialize(decodedTransaction),
+			claimable: response.claimable,
+		};
 	}
 }

--- a/src/types/token-launch.ts
+++ b/src/types/token-launch.ts
@@ -131,3 +131,46 @@ export type NormalizedCreateFeeShareConfigParams = {
 	bagsConfigType?: (typeof BAGS_CONFIG_TYPE)[keyof typeof BAGS_CONFIG_TYPE];
 	enableFirstSwapWithMinFee?: boolean;
 };
+
+export type DammV2VaultKind = 'partner' | 'deployer';
+
+export interface DammV2VaultClaimable {
+	/** Which aggregate vault this balance belongs to. */
+	kind: DammV2VaultKind;
+	/** Public key of the partner/deployer wallet. */
+	wallet: string;
+	/** Public key of the quote mint this vault is denominated in. */
+	quoteMint: string;
+	/** Decimals of the quote mint. */
+	quoteDecimals: number;
+	/** Public key of the vault's associated token account. */
+	vaultAta: string;
+	/** Claimable balance in quote mint base units. */
+	claimableAmount: number;
+	/** Claimable balance in whole quote tokens. */
+	claimableDisplayAmount: number;
+}
+
+export interface ClaimDammV2VaultParams {
+	/** Which aggregate vault to sweep. */
+	kind: DammV2VaultKind;
+	/** The partner/deployer wallet whose vault is being swept (also the destination). */
+	wallet: PublicKey;
+	/** Quote mint of the vault to sweep. */
+	quoteMint: PublicKey;
+}
+
+export interface ClaimDammV2VaultResponse {
+	/**
+	 * Gas-sponsored transaction that drains the vault to the wallet's ATA. The gas sponsor
+	 * is the fee payer; `params.wallet` only needs to co-sign as the authorizer.
+	 */
+	transaction: VersionedTransaction;
+	claimable: DammV2VaultClaimable;
+}
+
+/** @internal Wire shape before the transaction is decoded. */
+export interface ClaimDammV2VaultWireResponse {
+	transaction: string;
+	claimable: DammV2VaultClaimable;
+}

--- a/tests/services/token-launch.test.ts
+++ b/tests/services/token-launch.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, test } from 'vitest';
 import { LAMPORTS_PER_SOL, PublicKey, VersionedTransaction } from '@solana/web3.js';
 import { getTestSdk } from '../helpers/sdk';
 import { testEnv } from '../helpers/env';
+import { ApiError } from '../../src/api/bags-client';
 import type { CreateTokenInfoResponse } from '../../src/types/token-launch';
 
 let tokenInfoResponse: CreateTokenInfoResponse;
@@ -39,6 +40,24 @@ describe('TokenLaunchService integration', () => {
 		});
 
 		expect(transaction).toBeInstanceOf(VersionedTransaction);
+	});
+
+	test('claimDammV2Vault returns a claim transaction, or throws "Nothing to claim" for an empty vault', async () => {
+		const sdk = getTestSdk();
+
+		try {
+			const result = await sdk.tokenLaunch.claimDammV2Vault({
+				kind: 'partner',
+				wallet: testEnv.launchWallet,
+				quoteMint: testEnv.quoteMint,
+			});
+
+			expect(result.transaction).toBeInstanceOf(VersionedTransaction);
+			expect(result.claimable.wallet).toBe(testEnv.launchWallet.toBase58());
+		} catch (error) {
+			expect(error).toBeInstanceOf(ApiError);
+			expect((error as ApiError).status).toBe(400);
+		}
 	});
 });
 


### PR DESCRIPTION
Adds `tokenLaunch.claimDammV2Vault(params)`, wrapping the new public `POST /token-launch/damm-v2/claim-vault` endpoint: sweeps a partner/deployer's aggregate DAMM v2 vault to their wallet.

- Adds `DammV2VaultKind`, `DammV2VaultClaimable`, `ClaimDammV2VaultParams`, and `ClaimDammV2VaultResponse` types in `src/types/token-launch.ts`. `DammV2VaultClaimable` is shared with the `get-damm-v2-vault-claimables` SDK PR (#40) — whichever merges second will need a quick rebase.
- Adds `claimDammV2Vault` on `TokenLaunchService`. The returned transaction is decoded to a `VersionedTransaction`, matching the convention in `PartnerService` for other gas-sponsored claim transactions — the gas sponsor is the fee payer, so the caller only needs to co-sign as authorizer.
- Adds an integration test that builds (does not sign or submit) the claim transaction, tolerating the "Nothing to claim" 400 the backend returns for an empty vault, since the test wallet may not have a DAMM v2 vault balance.

The SDK is published manually with `npm publish` — a maintainer needs to release this before consumers can use it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGRrRXret9Sxez7XZGA7gM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fund-claiming flows (vault sweep + signed tx decode) but is a thin SDK wrapper around an existing API; no auth or on-chain program changes.
> 
> **Overview**
> Adds `tokenLaunch.claimDammV2Vault` to sweep a partner or deployer DAMM v2 aggregate vault for a quote mint.
> 
> The method posts to `/token-launch/damm-v2/claim-vault`, decodes the returned bs58 tx into a `VersionedTransaction`, and includes claimable balance metadata. The tx is gas-sponsored (sponsor is fee payer); the wallet only co-signs. Empty vaults throw `"Nothing to claim"`.
> 
> New types: `DammV2VaultKind`, `DammV2VaultClaimable`, `ClaimDammV2VaultParams`/`Response`. Integration test accepts either a built tx or a 400 for an empty vault. Note `DammV2VaultClaimable` is shared with the get-claimables PR and may need a rebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26b350838e52c9e3948d657ec36ef8c04e597b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->