### PR TITLE
feat: sync public api with backend pr 1228

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ new BagsSDK(apiKey: string, connection: Connection, commitment?: Commitment)
 | **Dexscreener** | `sdk.dexscreener` | Check order availability, create orders, and submit payments for Dexscreener listings |
 | **Auth** | `sdk.auth` | Fetch the API key owner's user profile |
 | **Robinhood** | `sdk.robinhood` | List Robinhood Chain claimable positions and build unsigned claim transactions |
+| **Dividends** | `sdk.dividends` | Read a token launch's dividend basket profile, live status, and distribution history |
 
 ### Exported Utilities
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,6 +11,7 @@ import { FeeShareAdminService } from './services/fee-share-admin';
 import { DexscreenerService } from './services/dexscreener';
 import { AuthService } from './services/auth';
 import { RobinhoodService } from './services/robinhood';
+import { DividendsService } from './services/dividends';
 
 export class BagsSDK {
 	public bagsApiClient: BagsApiClient;
@@ -25,6 +26,7 @@ export class BagsSDK {
 	public dexscreener: DexscreenerService;
 	public auth: AuthService;
 	public robinhood: RobinhoodService;
+	public dividends: DividendsService;
 
 	constructor(apiKey: string, connection: Connection, commitment: Commitment = 'processed') {
 		this.bagsApiClient = new BagsApiClient(apiKey);
@@ -39,5 +41,6 @@ export class BagsSDK {
 		this.dexscreener = new DexscreenerService(apiKey, connection, commitment);
 		this.auth = new AuthService(apiKey, connection, commitment);
 		this.robinhood = new RobinhoodService(apiKey, connection, commitment);
+		this.dividends = new DividendsService(apiKey, connection, commitment);
 	}
 }

--- a/src/services/dividends.ts
+++ b/src/services/dividends.ts
@@ -1,0 +1,61 @@
+import { Commitment, Connection, PublicKey } from '@solana/web3.js';
+import { BaseService } from './base';
+import { GetDividendHistoryParams, GetDividendHistoryResponse, GetDividendProfileBulkResponse, DividendProfileView, GetDividendStatusResponse } from '../types/dividends';
+
+export class DividendsService extends BaseService {
+	constructor(apiKey: string, connection: Connection, commitment: Commitment = 'processed') {
+		super(apiKey, connection, commitment);
+	}
+
+	/**
+	 * Get the dividend profile for a token launch.
+	 *
+	 * @param tokenMint The launch mint to look up
+	 * @returns The dividend profile, or null when the token has none
+	 */
+	async getProfile(tokenMint: PublicKey): Promise<DividendProfileView | null> {
+		return this.bagsApiClient.get<DividendProfileView | null>('/dividends/profile', {
+			params: { tokenMint: tokenMint.toBase58() },
+		});
+	}
+
+	/**
+	 * Get dividend profiles for up to 100 token launches in one request.
+	 *
+	 * @param tokenMints The launch mints to look up (1-100)
+	 * @returns The dividend profiles, aligned to and the same length as `tokenMints`, with null for mints without a profile
+	 */
+	async getProfilesBulk(tokenMints: PublicKey[]): Promise<GetDividendProfileBulkResponse> {
+		return this.bagsApiClient.post<GetDividendProfileBulkResponse>('/dividends/profile/bulk', {
+			tokenMints: tokenMints.map((tokenMint) => tokenMint.toBase58()),
+		});
+	}
+
+	/**
+	 * Get the live distribution status for a token launch's dividend basket.
+	 *
+	 * @param tokenMint The launch mint to look up
+	 * @returns The current phase, profile, and latest cycle
+	 */
+	async getStatus(tokenMint: PublicKey): Promise<GetDividendStatusResponse> {
+		return this.bagsApiClient.get<GetDividendStatusResponse>('/dividends/status', {
+			params: { tokenMint: tokenMint.toBase58() },
+		});
+	}
+
+	/**
+	 * Get completed distribution cycles for a token launch's dividend basket, newest first.
+	 *
+	 * @param params The token mint to look up, plus pagination options
+	 * @returns The page of completed cycles
+	 */
+	async getHistory(params: GetDividendHistoryParams): Promise<GetDividendHistoryResponse> {
+		return this.bagsApiClient.get<GetDividendHistoryResponse>('/dividends/history', {
+			params: {
+				tokenMint: params.tokenMint.toBase58(),
+				limit: params.limit,
+				cursor: params.cursor,
+			},
+		});
+	}
+}

--- a/src/services/token-launch.ts
+++ b/src/services/token-launch.ts
@@ -41,6 +41,7 @@ export class TokenLaunchService extends BaseService {
 			configKey: params.configKey.toBase58(),
 			tipWallet: params.tipConfig ? params.tipConfig.tipWallet.toBase58() : undefined,
 			tipLamports: params.tipConfig ? params.tipConfig.tipLamports : undefined,
+			dividendProfile: params.dividendProfile?.map((entry) => ({ mint: entry.mint.toBase58(), bps: entry.bps })),
 		});
 
 		const decodedSignedTransaction = bs58.decode(encodedSignedTransaction);
@@ -123,6 +124,7 @@ export class TokenLaunchService extends BaseService {
 			feeClaimerWallet: params.feeClaimerWallet?.toBase58(),
 			initialBuyQuoteAmount: params.initialBuyQuoteAmount,
 			partner: params.partner?.toBase58(),
+			dividendProfile: params.dividendProfile?.map((entry) => ({ mint: entry.mint.toBase58(), bps: entry.bps })),
 		});
 
 		return response;

--- a/src/types/dividends.ts
+++ b/src/types/dividends.ts
@@ -1,0 +1,158 @@
+import { PublicKey } from '@solana/web3.js';
+
+/** One constituent mint and its bps weight, for writing a dividend basket. */
+export interface DividendConstituentInput {
+	mint: PublicKey;
+	/** Basis-point share, integers >= 100. All entries in a basket must sum to exactly 10000. */
+	bps: number;
+}
+
+export interface DividendConstituentView {
+	/** Base58 constituent mint. Case-sensitive. */
+	mint: string;
+	bps: number;
+	decimals: number;
+	tokenProgram: string;
+	/** Token-2022 extension names present on the mint. */
+	extensions: string[];
+	/** True for the native-SOL passthrough constituent: no swap, paid out as lamports. */
+	isNativeSol: boolean;
+	name: string | null;
+	symbol: string | null;
+	image: string | null;
+}
+
+export interface DividendProfileStatsView {
+	completedDistributions: number;
+	totalClaimedLamports: string;
+	totalDistributedLamports: string;
+	lastDistributionAt: string | null;
+}
+
+export interface DividendProfileView {
+	tokenMint: string;
+	status: 'active' | 'disabled';
+	/** Monotonic config version. Bumped by the backend on every accepted change. */
+	version: number;
+	/** Informational: the size of the @DividendsBot fee-share row the frontend created. */
+	botFeeShareBps: number | null;
+	constituents: DividendConstituentView[];
+	/** Bot-maintained rollup. */
+	stats: DividendProfileStatsView;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export type GetDividendProfileBulkResponse = Array<DividendProfileView | null>;
+
+export type DividendPhase =
+	| 'idle'
+	| 'claiming'
+	| 'awaiting_funds'
+	| 'snapshotting_holders'
+	| 'buying_constituents'
+	| 'paying_holders'
+	| 'awaiting_recipients'
+	| 'awaiting_route'
+	| 'retrying'
+	| 'needs_review'
+	| 'completed';
+
+export interface DividendCurrentCycle {
+	/** The hourly cron slot, floor(now, 1h).toISOString(). */
+	cycleId: string;
+	claimStatus: string;
+	distributionStatus: string | null;
+	updatedAt: string;
+}
+
+export interface GetDividendStatusResponse {
+	phase: DividendPhase;
+	/** The current profile, carrying the bot's stats rollup, or null when the token has none. */
+	profile: DividendProfileView | null;
+	/** The latest cycle the bot worked on for this token; null when it has never run. */
+	currentCycle: DividendCurrentCycle | null;
+}
+
+export interface DividendHistoryClaim {
+	/** Base58 claim signature, or null when unavailable. */
+	signature: string | null;
+	claimedLamports: string;
+	slot: number | null;
+	confirmedAt: string | null;
+}
+
+export interface DividendHistoryBuy {
+	mint: string;
+	symbol: string | null;
+	image: string | null;
+	decimals: number;
+	/** The bps this cycle actually used, which may differ from the current profile. */
+	weightBpsUsed: number;
+	lamportsIn: string;
+	boughtAmountRaw: string | null;
+	/** True for the native-SOL passthrough slice: no swap happened. */
+	isNativeSol: boolean;
+	signature: string | null;
+	confirmedAt: string | null;
+}
+
+export interface DividendHistorySnapshot {
+	holderCount: number | null;
+	/** Distinct owners with at least one confirmed transfer. */
+	recipientCount: number;
+	excludedHolderCount: number;
+	includedSupply: string;
+	slot: number | null;
+	capturedAt: string | null;
+	/** True when the rent-budget shrink dropped the lowest-balance holders. */
+	truncated: boolean;
+}
+
+export interface DividendHistoryDistribution {
+	totalLamports: string;
+	distributableLamports: string;
+	/** ATA rent + wallet floor withheld from the claim before buying. */
+	reserveLamports: string;
+	snapshot: DividendHistorySnapshot;
+	/** Confirmed payout signatures in execution order. */
+	payoutSignatures: string[];
+	completedAt: string;
+}
+
+export interface DividendHistoryRecipient {
+	wallet: string;
+	snapshotBalanceRaw: string;
+	/** Empty when integer pro-rata rounded every constituent to zero. */
+	amounts: Array<{ mint: string; amountRaw: string }>;
+}
+
+export interface DividendHistoryItem {
+	/** Distribution ObjectId; stable feed-item id and the pagination cursor. */
+	id: string;
+	/** ISO-8601 distribution creation time used for feed ordering. */
+	timestamp: string;
+	/** One distribution aggregates every claim confirmed in its hourly cycle. */
+	claims: DividendHistoryClaim[];
+	buys: DividendHistoryBuy[];
+	distribution: DividendHistoryDistribution;
+	/** Up to ten non-excluded holders ranked by snapshot balance. */
+	topRecipients: DividendHistoryRecipient[];
+}
+
+export interface GetDividendHistoryParams {
+	tokenMint: PublicKey;
+	/** Page size, 1-50. Defaults to 20 server-side. */
+	limit?: number;
+	/** Cursor from a previous response's `nextCursor`. Omit for the first page. */
+	cursor?: string;
+}
+
+export interface GetDividendHistoryResponse {
+	/** Completed cycles, newest first. */
+	items: DividendHistoryItem[];
+	/** Whether another page exists after this page. */
+	hasMore: boolean;
+	/** Distribution ObjectId to send as cursor, or null when this is the final page. */
+	nextCursor: string | null;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,4 @@ export * from './trade';
 export * from './solana';
 export * from './dexscreener';
 export * from './robinhood';
+export * from './dividends';

--- a/src/types/token-launch.ts
+++ b/src/types/token-launch.ts
@@ -1,6 +1,7 @@
 import { PublicKey, VersionedTransaction } from '@solana/web3.js';
 import { BAGS_CONFIG_TYPE, TransactionTipConfig } from './api';
 import type { ImageInput } from '../utils/image';
+import type { DividendConstituentInput } from './dividends';
 
 export type GetOrCreateConfigResponse = {
 	transaction: VersionedTransaction | null;
@@ -19,6 +20,12 @@ export interface CreateLaunchTransactionParams {
 	initialBuyLamports: number;
 	configKey: PublicKey;
 	tipConfig?: TransactionTipConfig;
+	/**
+	 * Optional dividend basket, validated and persisted before the launch transaction is built
+	 * (a rejected constituent means no coin is launched). 1-10 entries, bps summing to exactly
+	 * 10000, no duplicate mints, no self-mint.
+	 */
+	dividendProfile?: DividendConstituentInput[];
 }
 
 export interface CreateDammV2LaunchTransactionParams {
@@ -36,6 +43,12 @@ export interface CreateDammV2LaunchTransactionParams {
 	initialBuyQuoteAmount?: number;
 	/** Existing PartnerConfig wallet to attach to the custody (its global bps applies). */
 	partner?: PublicKey;
+	/**
+	 * Optional dividend basket, validated and persisted before any transaction is built (a
+	 * rejected constituent means no coin is minted). 1-10 entries, bps summing to exactly
+	 * 10000, no duplicate mints, no self-mint.
+	 */
+	dividendProfile?: DividendConstituentInput[];
 }
 
 export type DammV2LaunchTransactionBundleItemType = 'LUT_SETUP' | 'CREATE_TOKEN' | 'LAUNCH' | 'LUT_DEACTIVATE' | 'LUT_CLOSE';

--- a/tests/services/dividends.test.ts
+++ b/tests/services/dividends.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest';
+import { getTestSdk } from '../helpers/sdk';
+import { testEnv } from '../helpers/env';
+
+describe('DividendsService', () => {
+	test('getProfile returns a profile or null for a known mint', async () => {
+		const sdk = getTestSdk();
+		const profile = await sdk.dividends.getProfile(testEnv.tokenMint);
+
+		if (profile) {
+			expect(profile.tokenMint).toBe(testEnv.tokenMint.toBase58());
+			expect(['active', 'disabled']).toContain(profile.status);
+			expect(Array.isArray(profile.constituents)).toBe(true);
+		} else {
+			expect(profile).toBeNull();
+		}
+	});
+
+	test('getProfilesBulk returns one entry per input mint, in order', async () => {
+		const sdk = getTestSdk();
+		const profiles = await sdk.dividends.getProfilesBulk([testEnv.tokenMint, testEnv.notUsedBagsTokenMint]);
+
+		expect(profiles.length).toBe(2);
+		expect(profiles[1]).toBeNull();
+	});
+
+	test('getStatus returns a live phase for a known mint', async () => {
+		const sdk = getTestSdk();
+		const status = await sdk.dividends.getStatus(testEnv.tokenMint);
+
+		expect(typeof status.phase).toBe('string');
+		expect(status.profile === null || typeof status.profile === 'object').toBe(true);
+		expect(status.currentCycle === null || typeof status.currentCycle === 'object').toBe(true);
+	});
+
+	test('getStatus returns idle for a mint with no dividend activity', async () => {
+		const sdk = getTestSdk();
+		const status = await sdk.dividends.getStatus(testEnv.notUsedBagsTokenMint);
+
+		expect(status.phase).toBe('idle');
+		expect(status.profile).toBeNull();
+		expect(status.currentCycle).toBeNull();
+	});
+
+	test('getHistory returns a paginated page of completed cycles', async () => {
+		const sdk = getTestSdk();
+		const page = await sdk.dividends.getHistory({ tokenMint: testEnv.tokenMint, limit: 5 });
+
+		expect(Array.isArray(page.items)).toBe(true);
+		expect(page.items.length).toBeLessThanOrEqual(5);
+		expect(typeof page.hasMore).toBe('boolean');
+
+		if (page.items.length > 0) {
+			const [first] = page.items;
+			expect(typeof first.id).toBe('string');
+			expect(Array.isArray(first.claims)).toBe(true);
+			expect(Array.isArray(first.buys)).toBe(true);
+		}
+	});
+
+	test('getHistory returns an empty page for a mint with no dividend activity', async () => {
+		const sdk = getTestSdk();
+		const page = await sdk.dividends.getHistory({ tokenMint: testEnv.notUsedBagsTokenMint });
+
+		expect(page.items).toEqual([]);
+		expect(page.hasMore).toBe(false);
+		expect(page.nextCursor).toBeNull();
+	});
+});


### PR DESCRIPTION
Backend PR: bagsfm/bags.backend#1228 added Solana dividend baskets for token launches. Adds a new `dividends` service for the read surface and threads the new optional launch field through.

Public API PR: bagsfm/bags-public-api-v2#64
Docs PR: bagsfm/bags-public-api-v2-docs#42
CLI PR: bagsfm/bags-cli#17

### New `DividendsService` (`sdk.dividends`)
New endpoints. Added `src/types/dividends.ts` with the full response shape (`DividendProfileView`, `GetDividendStatusResponse`, `GetDividendHistoryResponse`, etc.) and `src/services/dividends.ts` with:
- `getProfile(tokenMint)` — `GET /dividends/profile`
- `getProfilesBulk(tokenMints)` — `POST /dividends/profile/bulk`
- `getStatus(tokenMint)` — `GET /dividends/status`
- `getHistory({ tokenMint, limit?, cursor? })` — `GET /dividends/history`

Registered on `BagsSDK` as `sdk.dividends`, added to the services table in `README.md`, and covered by `tests/services/dividends.test.ts`.

### `dividendProfile` on launch transactions (contract update)
`createLaunchTransaction` and `createDammV2LaunchTransaction` both gained an optional `dividendProfile?: DividendConstituentInput[]` param (mirrors the backend's optional field), threaded through to the request body as `{ mint: base58, bps }`.

This package is published manually with `npm publish` — a maintainer needs to release after merging before `bags-cli` can pick up the new `dividends` service and updated launch params (see the CLI PR).
