### PR TITLE
docs: note jupiter trending whitelist on damm v2 quote mint params

### DIFF
--- a/src/services/token-launch.ts
+++ b/src/services/token-launch.ts
@@ -109,7 +109,9 @@ export class TokenLaunchService extends BaseService {
 	 * Builds the partially-signed transaction bundle that launches a token previously
 	 * registered via `createTokenInfoAndMetadata` straight into a single-sided DAMM v2
 	 * customizable pool (no DBC bonding curve, no migration). Every transaction in the
-	 * bundle must be co-signed by `params.wallet` before submission.
+	 * bundle must be co-signed by `params.wallet` before submission. `params.quoteMint`
+	 * must currently be badged and in the Jupiter trending-stocks whitelist; a mint that
+	 * built successfully before can fail here if it has since rotated out.
 	 *
 	 * @param params The parameters for the DAMM v2 direct launch
 	 * @returns The transaction bundle and launch details
@@ -149,7 +151,9 @@ export class TokenLaunchService extends BaseService {
 	/**
 	 * Get DAMM v2 supported quote tokens
 	 *
-	 * Every quote mint currently usable for DAMM v2 direct launches.
+	 * Every quote mint currently usable for DAMM v2 direct launches: mints holding a
+	 * cp-amm TokenBadge that are also in the Jupiter trending-stocks whitelist (top 100
+	 * by 24h volume, refreshed every 6 hours). A mint can rotate in and out of this list.
 	 *
 	 * @returns The supported quote tokens
 	 */

--- a/src/types/token-launch.ts
+++ b/src/types/token-launch.ts
@@ -28,7 +28,7 @@ export interface CreateDammV2LaunchTransactionParams {
 	tokenMint: PublicKey;
 	/** Launch wallet; fee payer and signer of every transaction in the bundle. */
 	wallet: PublicKey;
-	/** Badged quote mint (see `getDammV2SupportedQuoteTokens`). */
+	/** Quote mint eligible at build time (see `getDammV2SupportedQuoteTokens`) — must hold a cp-amm TokenBadge and currently be in the Jupiter trending-stocks whitelist; eligibility can change as the whitelist rotates. */
 	quoteMint: PublicKey;
 	/** Receives the 50% fee position NFT; defaults to `wallet`. */
 	feeClaimerWallet?: PublicKey;


### PR DESCRIPTION
Follow-up to bagsfm/bags.backend#1235, which tightened DAMM v2 direct-launch quote mint eligibility: a mint must now hold a cp-amm `TokenBadge` **and** appear in Jupiter's top-100 trending stocks by 24h volume (refreshed every 6 hours), not just the badge alone. The list rotates, so a mint that worked earlier can drop out.

No request/response types or method signatures changed — this is a JSDoc-only update so consumers aren't caught off guard by a previously-successful `quoteMint` starting to fail.

### `createDammV2LaunchTransaction`

Updated the JSDoc and the `CreateDammV2LaunchTransactionParams.quoteMint` field comment to note the mint must currently be badged and in the trending whitelist, and that this can change between calls.

### `getDammV2SupportedQuoteTokens`

Updated the JSDoc to describe the dual filter (badge + trending whitelist) behind the returned list.

Sibling PRs: bagsfm/bags-public-api-v2-docs#43

Note: this package is published manually via `npm publish` — no release is required for this change since nothing in the published API surface changed, just JSDoc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc and inline comments only; no executable code or published API surface changes.
> 
> **Overview**
> **Documentation-only** update for DAMM v2 direct launch quote mint rules, aligned with backend eligibility (cp-amm `TokenBadge` plus Jupiter trending-stocks whitelist).
> 
> JSDoc on `createDammV2LaunchTransaction` and `getDammV2SupportedQuoteTokens` now states that supported quotes are badged mints also in the top-100 trending stocks by 24h volume (refreshed every ~6 hours), and that a mint can leave the list after a prior successful build. The `CreateDammV2LaunchTransactionParams.quoteMint` field comment is updated the same way and points integrators at `getDammV2SupportedQuoteTokens`.
> 
> No API signatures, types, or runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7496fe5c53d981c35fee5f2beb2587cc89d2b5af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->