### PR TITLE
feat: add rh 24h price change and volume fields

### DIFF
--- a/src/types/robinhood.ts
+++ b/src/types/robinhood.ts
@@ -29,6 +29,15 @@ export interface RobinhoodToken {
 export interface RobinhoodTopVolumeItem extends RobinhoodToken {
 	priceEthPerToken: string | null;
 	bondingProgressPct: number;
+	/**
+	 * Spot price change over the last 24h in percent units (e.g. `-12.34` means -12.34%).
+	 * Baseline is the last trade at or before 24h ago, falling back to the curve's initial
+	 * spot for tokens with no trade before that cutoff. Null only when `priceEthPerToken`
+	 * is null (or the baseline could not be resolved) — 0 is a real "unchanged" value.
+	 */
+	priceChange24hPct: number | null;
+	/** ETH-leg trade volume over the last 24h, in wei as a decimal string. */
+	volume24hEthWei: string;
 	volumeEthWei: string;
 }
 

--- a/tests/services/robinhood.test.ts
+++ b/tests/services/robinhood.test.ts
@@ -23,6 +23,8 @@ describe('RobinhoodService getTopVolume', () => {
 		expect(typeof item.address).toBe('string');
 		expect(typeof item.volumeEthWei).toBe('string');
 		expect(typeof item.bondingProgressPct).toBe('number');
+		expect(typeof item.volume24hEthWei).toBe('string');
+		expect(item.priceChange24hPct === null || typeof item.priceChange24hPct === 'number').toBe(true);
 	});
 
 	test('items are sorted by volumeEthWei descending', () => {


### PR DESCRIPTION
Syncs with [bags.backend#1237](https://github.com/bagsfm/bags.backend/pull/1237) and [bags-public-api-v2-docs#44](https://github.com/bagsfm/bags-public-api-v2-docs/pull/44).

### `robinhood.getTopVolume()` items gain 24h stats

`RobinhoodTopVolumeItem` now includes `priceChange24hPct` (nullable percent, null only when `priceEthPerToken` is null or a baseline couldn't be resolved — `0` is a real "unchanged" value) and `volume24hEthWei` (wei decimal string), alongside the existing lifetime `volumeEthWei`. Extended the existing integration test to assert the new fields' shape.

No other Robinhood or DAMM v2 methods change shape here — the backend PR also adds a `503` to the DAMM v2 supported-quote-tokens and create-transaction endpoints for a total whitelist outage, but that surfaces through the existing generic `ApiError` path with no SDK code change needed.

This package is published manually with `npm publish` — a maintainer needs to cut a release after this merges before the CLI (or other consumers) can pick it up.


---
_Generated by [Claude Code](https://claude.ai/code/session_014XfdVPU9mjkSuxTomCS4A8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API surface on types and tests only; no runtime logic or auth changes in the SDK.
> 
> **Overview**
> Extends **`RobinhoodTopVolumeItem`** (returned by `robinhood.getTopVolume()`) with **`priceChange24hPct`** — nullable 24h spot price change in percent, with documented baseline rules — and **`volume24hEthWei`** — 24h ETH-leg volume as a wei decimal string — while keeping lifetime **`volumeEthWei`** and existing sort behavior unchanged.
> 
> The Robinhood service still deserializes the same `/evm/rh/top-volume` response; this PR is mainly **type + doc alignment** with the backend. Integration tests now assert the new fields’ types on live responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d5527975de6a56064da91a08504d57bbe038c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->