### PR TITLE
feat: add v3 quote-asset fields to robinhood chain types

### DIFF
--- a/src/types/robinhood.ts
+++ b/src/types/robinhood.ts
@@ -1,8 +1,24 @@
-export type RobinhoodProtocolVersion = 'v1' | 'v2';
+export type RobinhoodProtocolVersion = 'v1' | 'v2' | 'v3';
 
 export interface RobinhoodTokenMetadata {
 	image: string | null;
 	description: string | null;
+}
+
+/** Settlement asset of a launch: WETH for V1/V2 and native V3 launches, or an allowlisted ERC20 for a V3 launch that opted into one. */
+export interface RobinhoodQuoteAsset {
+	address: string;
+	symbol: string;
+	decimals: number;
+	isNative: boolean;
+}
+
+/** Per-side V3 fee rates for a launch. Not present on V1/V2 launches, which always charge the fixed 2% protocol fee. */
+export interface RobinhoodFeeConfig {
+	buyFeeBps: number;
+	sellFeeBps: number;
+	protocolBuyFeeBps: number;
+	protocolSellFeeBps: number;
 }
 
 export interface RobinhoodToken {
@@ -24,12 +40,16 @@ export interface RobinhoodToken {
 	migratedAtBlock: number | null;
 	migratedAtTimestamp: number | null;
 	version?: RobinhoodProtocolVersion;
+	quote: RobinhoodQuoteAsset;
+	fees?: RobinhoodFeeConfig;
 }
 
 export interface RobinhoodTopVolumeItem extends RobinhoodToken {
 	priceEthPerToken: string | null;
+	priceQuotePerToken: string | null;
 	bondingProgressPct: number;
 	volumeEthWei: string;
+	volumeQuoteWei: string;
 }
 
 export interface RobinhoodTopVolumeResponse {
@@ -48,6 +68,7 @@ export interface RobinhoodClaimablePosition {
 	isClaimer: boolean;
 	isPartner: boolean;
 	userBps: number;
+	quote: RobinhoodQuoteAsset;
 }
 
 export interface RobinhoodClaimablePositions {
@@ -71,7 +92,9 @@ export interface RobinhoodClaimTransactions {
 	pendingWei: string;
 	actionableWei: string;
 	chainId: 4663;
-	unwrap: true;
+	/** True for WETH-quoted launches (V1, V2, and native V3 launches); false for a V3 launch quoted in an ERC20, whose fee-share pays out the ERC20 directly. */
+	unwrap: boolean;
+	quote: RobinhoodQuoteAsset;
 	transactions: Array<RobinhoodClaimTransaction>;
 }
 

--- a/tests/services/robinhood.test.ts
+++ b/tests/services/robinhood.test.ts
@@ -22,7 +22,10 @@ describe('RobinhoodService getTopVolume', () => {
 
 		expect(typeof item.address).toBe('string');
 		expect(typeof item.volumeEthWei).toBe('string');
+		expect(typeof item.volumeQuoteWei).toBe('string');
 		expect(typeof item.bondingProgressPct).toBe('number');
+		expect(typeof item.quote.address).toBe('string');
+		expect(typeof item.quote.symbol).toBe('string');
 	});
 
 	test('items are sorted by volumeEthWei descending', () => {
@@ -42,6 +45,12 @@ describe.skipIf(!testEnv.robinhoodOwner)('RobinhoodService integration', () => {
 	test('getClaimablePositions returns positions and truncation state', () => {
 		expect(Array.isArray(claimablePositions.positions)).toBe(true);
 		expect(typeof claimablePositions.truncated).toBe('boolean');
+
+		const position = claimablePositions.positions[0];
+
+		if (position) {
+			expect(typeof position.quote.address).toBe('string');
+		}
 	});
 
 	test('createClaimTransactions returns unsigned EVM transactions', async () => {
@@ -57,7 +66,8 @@ describe.skipIf(!testEnv.robinhoodOwner)('RobinhoodService integration', () => {
 		});
 
 		expect(result.chainId).toBe(4663);
-		expect(result.unwrap).toBe(true);
+		expect(typeof result.unwrap).toBe('boolean');
+		expect(typeof result.quote.address).toBe('string');
 		expect(result.transactions.length).toBeGreaterThan(0);
 
 		result.transactions.forEach((transaction) => {


### PR DESCRIPTION
Syncs the SDK with backend PR bagsfm/bags.backend#1249 ("feat: evm v3"), which adds Bags V3 on Robinhood Chain alongside legacy V1/V2. V3 launches settle in a per-launch quote asset (WETH or an allowlisted ERC20) and carry per-side fee rates.

The SDK currently wraps three of the affected robinhood chain endpoints — `getTopVolume`, `getClaimablePositions`, `createClaimTransactions` — so this PR updates only those. The other affected endpoints aren't wrapped by the SDK yet, so there's nothing to update for them here.

### Types (`src/types/robinhood.ts`)
- `RobinhoodProtocolVersion` widens from `'v1' | 'v2'` to `'v1' | 'v2' | 'v3'`.
- New shared types: `RobinhoodQuoteAsset` (`address`, `symbol`, `decimals`, `isNative`) and `RobinhoodFeeConfig` (`buyFeeBps`, `sellFeeBps`, `protocolBuyFeeBps`, `protocolSellFeeBps`).
- `RobinhoodToken` gains a required `quote` and optional `fees` (V3 only).
- `RobinhoodTopVolumeItem` gains `priceQuotePerToken` and `volumeQuoteWei`.
- `RobinhoodClaimablePosition` gains `quote`.
- `RobinhoodClaimTransactions` gains `quote`.

### Breaking change for SDK consumers
`RobinhoodClaimTransactions.unwrap` changes from the literal type `true` to `boolean`. A V3 launch quoted in an ERC20 pays out that asset directly instead of unwrapping to native ETH, so `unwrap` can now be `false`. Any consumer code that narrowed on the literal `true` type will need updating.

### Tests
Updated `tests/services/robinhood.test.ts` (live integration tests) to assert `quote`/`volumeQuoteWei` are present and to check `unwrap`'s type rather than asserting it's always `true`. These require live credentials (`BAGS_API_KEY`, `SOLANA_RPC_URL`, etc.) and could not be run in this environment — verified `npm run build`, `npx eslint`, and `npx prettier --check` pass clean on the changed files instead.

**Note:** this package is published manually with `npm publish` — a maintainer needs to release a new version after merging for downstream consumers (including bags-cli) to pick this up.

Docs PR: bagsfm/bags-public-api-v2-docs#45


---
_Generated by [Claude Code](https://claude.ai/code/session_01JvCFp6ckdoYsy6zbN3rCeA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking TypeScript change on `unwrap` and new required `quote` fields may break consumers until they handle V3 quote assets; runtime SDK behavior is still API passthrough.
> 
> **Overview**
> Extends Robinhood Chain SDK types for **Bags V3** launches that settle in a per-launch quote asset (WETH/native or an allowlisted ERC20) instead of assuming ETH-only flows.
> 
> `RobinhoodProtocolVersion` adds **`v3`**, with new **`RobinhoodQuoteAsset`** and optional **`RobinhoodFeeConfig`** on tokens. **`quote`** is now required on tokens, claimable positions, and claim-transaction payloads; top-volume items also expose **`priceQuotePerToken`** and **`volumeQuoteWei`**. **`RobinhoodClaimTransactions.unwrap`** is no longer typed as always `true`—it is **`boolean`** when V3 ERC20-quoted launches pay fees in the quote token without unwrapping.
> 
> Integration tests assert the new **`quote`** / **`volumeQuoteWei`** fields and relax **`unwrap`** expectations from a literal `true` to a boolean check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d3da531cf7f6d5b76ded935c9e514d9fdbaa00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->